### PR TITLE
ENH: reversed structure

### DIFF
--- a/refnx/reflect/structure.py
+++ b/refnx/reflect/structure.py
@@ -17,7 +17,36 @@ class Structure(UserList):
     Represents the interfacial Structure of a reflectometry sample. Successive
     Components are added to the Structure to construct the interface.
     """
-    def __init__(self, name='', solvent='backing'):
+    def __init__(self, name='', solvent='backing', reversed=False):
+        """
+        Represents the interfacial Structure of a reflectometry sample.
+        Successive Components are added to the Structure to construct the
+        interface.
+
+        Parameters
+        ----------
+        name : str
+            Name of this structure
+        solvent : str
+            Specifies whether the 'backing' or 'fronting' semi-infinite medium
+            is used to solvate components. You would typically use 'backing'
+            for neutron reflectometry, with solvation by the material in
+            Structure[-1]. X-ray reflectometry would typically be solvated by
+            the 'fronting' material in Structure[0].
+        reversed : bool
+            If `Structure.reversed` is `True` then the slab representation
+            produced by `Structure.slabs` is reversed. The sld profile and
+            calculated reflectivity will correspond to this reversed structure.
+
+        Notes
+        -----
+        If `Structure.reversed is True` then the slab representation order is
+        reversed. The slab order is reversed before the solvation calculation
+        is done. I.e. if `Structure.solvent == 'backing'` and
+        `Structure.reversed is True` then the material that solvates the system
+        is the component in `Structure[0]`, which corresponds to
+        `Structure.slab[-1]`.
+        """
         super(Structure, self).__init__()
         self._name = name
         if solvent not in ['backing', 'fronting']:
@@ -25,6 +54,7 @@ class Structure(UserList):
                              " medium")
 
         self.solvent = solvent
+        self._reversed = bool(reversed)
         # self._parameters = Parameters(name=name)
 
     def __copy__(self):
@@ -55,9 +85,17 @@ class Structure(UserList):
         self._name = name
 
     @property
+    def reversed(self):
+        return bool(self._reversed)
+
+    @reversed.setter
+    def reversed(self, reversed):
+        self._reversed = reversed
+
+    @property
     def slabs(self):
         """
-        Slab representation of this structure
+        Slab representation of this structure.
 
         Returns
         -------
@@ -69,6 +107,15 @@ class Structure(UserList):
             slab[N, 3] - roughness between layer N and N-1
             slab[N, 4] - volume fraction of solvent in layer N.
                          (1 - solvent_volfrac = material_volfrac)
+
+        Notes
+        -----
+        If `Structure.reversed is True` then the slab representation order is
+        reversed. The slab order is reversed before the solvation calculation
+        is done. I.e. if `Structure.solvent == 'backing'` and
+        `Structure.reversed is True` then the material that solvates the system
+        is the component in `Structure[0]`, which corresponds to
+        `Structure.slab[-1]`.
         """
         if not len(self):
             return None
@@ -91,6 +138,13 @@ class Structure(UserList):
             i += new_slabs
 
         slabs = slabs[:i]
+
+        # if the slab representation needs to be reversed.
+        if self.reversed:
+            roughnesses = slabs[1:, 3]
+            slabs = np.flipud(slabs)
+            slabs[1:, 3] = roughnesses[::-1]
+            slabs[0, 3] = 0.
 
         if len(self) > 2:
             if self.solvent == 'backing':

--- a/refnx/reflect/structure.py
+++ b/refnx/reflect/structure.py
@@ -17,7 +17,7 @@ class Structure(UserList):
     Represents the interfacial Structure of a reflectometry sample. Successive
     Components are added to the Structure to construct the interface.
     """
-    def __init__(self, name='', solvent='backing', reversed=False):
+    def __init__(self, name='', solvent='backing', reverse_structure=False):
         """
         Represents the interfacial Structure of a reflectometry sample.
         Successive Components are added to the Structure to construct the
@@ -33,18 +33,19 @@ class Structure(UserList):
             for neutron reflectometry, with solvation by the material in
             Structure[-1]. X-ray reflectometry would typically be solvated by
             the 'fronting' material in Structure[0].
-        reversed : bool
-            If `Structure.reversed` is `True` then the slab representation
-            produced by `Structure.slabs` is reversed. The sld profile and
-            calculated reflectivity will correspond to this reversed structure.
+        reverse_structure : bool
+            If `Structure.reverse_structure` is `True` then the slab
+            representation produced by `Structure.slabs` is reversed. The sld
+            profile and calculated reflectivity will correspond to this
+            reversed structure.
 
         Notes
         -----
-        If `Structure.reversed is True` then the slab representation order is
-        reversed. The slab order is reversed before the solvation calculation
-        is done. I.e. if `Structure.solvent == 'backing'` and
-        `Structure.reversed is True` then the material that solvates the system
-        is the component in `Structure[0]`, which corresponds to
+        If `Structure.reverse_structure is True` then the slab representation
+        order is reversed. The slab order is reversed before the solvation
+        calculation is done. I.e. if `Structure.solvent == 'backing'` and
+        `Structure.reverse_structure is True` then the material that solvates
+        the system is the component in `Structure[0]`, which corresponds to
         `Structure.slab[-1]`.
         """
         super(Structure, self).__init__()
@@ -54,7 +55,7 @@ class Structure(UserList):
                              " medium")
 
         self.solvent = solvent
-        self._reversed = bool(reversed)
+        self._reverse_structure = bool(reverse_structure)
         # self._parameters = Parameters(name=name)
 
     def __copy__(self):
@@ -85,12 +86,12 @@ class Structure(UserList):
         self._name = name
 
     @property
-    def reversed(self):
-        return bool(self._reversed)
+    def reverse_structure(self):
+        return bool(self._reverse_structure)
 
-    @reversed.setter
-    def reversed(self, reversed):
-        self._reversed = reversed
+    @reverse_structure.setter
+    def reverse_structure(self, reverse_structure):
+        self._reverse_structure = reverse_structure
 
     @property
     def slabs(self):
@@ -140,7 +141,7 @@ class Structure(UserList):
         slabs = slabs[:i]
 
         # if the slab representation needs to be reversed.
-        if self.reversed:
+        if self.reverse_structure:
             roughnesses = slabs[1:, 3]
             slabs = np.flipud(slabs)
             slabs[1:, 3] = roughnesses[::-1]

--- a/refnx/reflect/test/test_reflect.py
+++ b/refnx/reflect/test/test_reflect.py
@@ -170,7 +170,7 @@ class TestReflect(unittest.TestCase):
         air = SLD(0, name='air')
         si = SLD(2.07, name='Si')
         structure = si | sio2(100, 3) | air(0, 2)
-        structure.reversed = True
+        structure.reverse_structure = True
 
         assert_equal(structure.slabs, self.structure.slabs)
 

--- a/refnx/reflect/test/test_reflect.py
+++ b/refnx/reflect/test/test_reflect.py
@@ -164,6 +164,19 @@ class TestReflect(unittest.TestCase):
         calc2 = _creflect.abeles(self.qvals, layer2, scale=0.99, bkg=1e-8)
         assert_almost_equal(calc1, calc2)
 
+    def test_reverse(self):
+        # check that the structure reversal works.
+        sio2 = SLD(3.47, name='SiO2')
+        air = SLD(0, name='air')
+        si = SLD(2.07, name='Si')
+        structure = si | sio2(100, 3) | air(0, 2)
+        structure.reversed = True
+
+        assert_equal(structure.slabs, self.structure.slabs)
+
+        calc = structure.reflectivity(self.qvals)
+        assert_almost_equal(calc, self.rvals)
+
     def test_c_abeles_reshape(self):
         # c reflectivity should be able to deal with multidimensional input
         if not TEST_C_REFLECT:


### PR DESCRIPTION
add `reversed` attribute to `refnx.reflect.Structure`. This enables you to calculate the front/back reflectivity from the same structure very easily.