### PR TITLE
MAINT: thin during sampling (otherwise memory can explode)

### DIFF
--- a/refnx/analysis/curvefitter.py
+++ b/refnx/analysis/curvefitter.py
@@ -317,7 +317,7 @@ class CurveFitter(object):
         For example, the chain is contained in `CurveFitter.sampler.chain` and
         has shape `(nwalkers, iterations, ndim)`. If you wish to 'burn' a
         number of samples to start with then use the following pattern:
-        
+
         >>> # we'll burn the first 500
         >>> fitter.sample(500)
         >>> # after you've run those, then discard them by resetting the
@@ -325,7 +325,7 @@ class CurveFitter(object):
         >>> fitter.sampler.reset()
         >>> # Now do a production run only saving 1 in every 50 samples
         >>> fitter.sample(2000, nthin=50)
-        
+
         One can also burn and thin in `Curvefitter.process_chain`.
         """
         if self._lastpos is None:

--- a/refnx/reflect/test/test_reflect.py
+++ b/refnx/reflect/test/test_reflect.py
@@ -235,8 +235,7 @@ class TestReflect(object):
         fitter = CurveFitter(objective, threads=4)
 
         res = fitter.fit('differential_evolution')
-        res_mcmc = fitter.sample(steps=50, nburn=20, nthin=10,
-                                 random_state=1, verbose=False)
+        res_mcmc = fitter.sample(steps=50, nthin=10, random_state=1, verbose=False)
 
         mcmc_val = [mcmc_result.median for mcmc_result in res_mcmc]
         assert_allclose(mcmc_val, res.x, rtol=0.05)

--- a/refnx/reflect/test/test_reflect.py
+++ b/refnx/reflect/test/test_reflect.py
@@ -235,7 +235,8 @@ class TestReflect(object):
         fitter = CurveFitter(objective, threads=4)
 
         res = fitter.fit('differential_evolution')
-        res_mcmc = fitter.sample(steps=50, nthin=10, random_state=1, verbose=False)
+        res_mcmc = fitter.sample(steps=50, nthin=10, random_state=1,
+                                 verbose=False)
 
         mcmc_val = [mcmc_result.median for mcmc_result in res_mcmc]
         assert_allclose(mcmc_val, res.x, rtol=0.05)


### PR DESCRIPTION
THin during sampling. This reduces the memory footprint significantly, which is an issue for large chain sizes.
This PR also removes the nburn kwd. One can always use process_chain to do any further burning and thinning.