### PR TITLE
BUG: ensure fname_dat set in all code paths

### DIFF
--- a/refnx/reduce/reduce.py
+++ b/refnx/reduce/reduce.py
@@ -543,6 +543,8 @@ def reduce_stitch(reflect_list, direct_list, norm_file_num=None,
         fname_xml = 'c_{0}.xml'.format(fname)
         with open(fname_xml, 'wb') as f:
             combined_dataset.save_xml(f)
+    else:
+        fname_dat = None
 
     return combined_dataset, fname_dat
 


### PR DESCRIPTION
If `reduce_stitch` is used with `save=False` then `fname_dat` is not defined leading to a `NameError`.