### PR TITLE
BUG: fix run number selection from cache

### DIFF
--- a/refnx/reduce/batchreduction.py
+++ b/refnx/reduce/batchreduction.py
@@ -135,7 +135,7 @@ class ReductionCache(list):
         run_numbers : iterable
             run numbers to find
         """
-        return [self.run_cache[r] for r in run_numbers]
+        return [self[self.run_cache[r]] for r in run_numbers]
 
     def row(self, row_number):
         """ select a single data set by spreadsheet row number

--- a/refnx/reduce/test/test_batch_reduce.py
+++ b/refnx/reduce/test/test_batch_reduce.py
@@ -94,6 +94,8 @@ class TestReductionCache(object):
 
     def test_runs(self):
         assert_equal(len(self.cache.runs((2, 12))), 2)
+        assert_(type(self.cache.runs([2])[0])
+                is refnx.reduce.batchreduction.ReductionEntry)
 
     def test_row(self):
         from pytest import raises


### PR DESCRIPTION
Code to extract runs based on run numbers was collecting only the indexes in the cache not the actual data.