### PR TITLE
Batch reducer improvements

### DIFF
--- a/refnx/reduce/batchreduction.py
+++ b/refnx/reduce/batchreduction.py
@@ -283,7 +283,7 @@ class ReductionCache(list):
 
     def _repr_html_(self):
         df = self._summary_dataframe()
-        return "<b>Summary of reduced data</b>" + df._repr_html_()
+        return "<b>Summary of reduced data</b>" + df.fillna("")._repr_html_()
 
     def __str__(self):
         df = self._summary_dataframe()
@@ -383,7 +383,18 @@ class BatchReducer:
 
     def load_runs(self):
         cols = 'A:I'
-        all_runs = pd.read_excel(self.filename, parse_cols=cols)
+        all_runs = pd.read_excel(
+            self.filename,
+            parse_cols=cols,
+            converters={
+                'refl1': int,
+                'refl2': int,
+                'refl3': int,
+                'dir1': int,
+                'dir2': int,
+                'dir3': int,
+            },
+        )
 
         # Add the row number in the spreadsheet as an extra column
         # row numbers for the runs will start at 2 not 0
@@ -445,7 +456,7 @@ class BatchReducer:
 
         if show:
             if _have_ipython:
-                IPython.display.display(all_runs[mask])
+                IPython.display.display(all_runs[mask].fillna(""))
             else:
                 print(all_runs[mask])
 

--- a/refnx/reduce/batchreduction.py
+++ b/refnx/reduce/batchreduction.py
@@ -364,17 +364,17 @@ class BatchReducer:
             sys.stdout.flush()   # keep progress updated
 
         if not runs:
-            warnings.warn("Row %d (%s) has no reflection runs" %
+            warnings.warn("Row %d (%s) has no reflection runs. Skipped." %
                           (entry['source'], entry['name']))
             return None, None
         if not directs:
-            warnings.warn("Row %d (%s) has no direct beam runs" %
+            warnings.warn("Row %d (%s) has no direct beam runs. Skipped." %
                           (entry['source'], entry['name']))
             return None, None
 
-        if len(runs) != len(directs):
+        if len(runs) > len(directs):
             warnings.warn("Row %d (%s) has differing numbers of"
-                          " direct & refln runs" %
+                          " direct & reflection runs. Skipped." %
                           (entry['source'], entry['name']))
             return None, None
 

--- a/refnx/reduce/batchreduction.py
+++ b/refnx/reduce/batchreduction.py
@@ -136,6 +136,19 @@ class ReductionCache(list):
             self.write_cache()
         return data
 
+    def delete_rows(self, row_numbers):
+        for row in row_numbers:
+            if row not in self.row_cache:
+                print("Not deleting unknown row %s" % row)
+                continue
+
+            self[self.row_cache[row]] = None
+            del self.row_cache[row]
+            print("Deleted row %s" % row)
+
+        if self.persistent:
+            self.write_cache()
+
     def run(self, run_number):
         """ select a single data set by run number
 
@@ -174,7 +187,8 @@ class ReductionCache(list):
         row_numbers : iterable
             row numbers to find
         """
-        return [entry for entry in self if entry.row in row_numbers]
+        return [entry for entry in self
+                if entry is not None and entry.row in row_numbers]
 
     def name(self, name):
         """ select a single data set by sample name
@@ -194,7 +208,8 @@ class ReductionCache(list):
         name : str
             fragment that must be at the start of the sample name
         """
-        matches = [entry for entry in self if entry.name.startswith(name)]
+        matches = [entry for entry in self
+                   if entry is not None and entry.name.startswith(name)]
         return matches
 
     def name_search(self, search):
@@ -223,7 +238,8 @@ class ReductionCache(list):
             name_re = re.compile(search)
         else:
             name_re = search
-        matches = [entry for entry in self if name_re.search(entry.name)]
+        matches = [entry for entry in self
+                   if entry is not None and name_re.search(entry.name)]
         return matches
 
     def summary(self):
@@ -242,7 +258,8 @@ class ReductionCache(list):
         """
         df = pd.DataFrame(columns=self[0].entry.axes)
         for i, entry in enumerate(self):
-            df.loc[i] = entry.entry
+            if entry is not None:
+                df.loc[i] = entry.entry
         return df
 
     def write_cache(self, filename=None):

--- a/refnx/reduce/batchreduction.py
+++ b/refnx/reduce/batchreduction.py
@@ -306,7 +306,8 @@ class BatchReducer:
 
         reduce name scale refl1 refl2 refl3 dir1 dir2 dir3
 
-    Only rows where the value of the `reduce` column is 1 will be processed.
+    Only rows where the value of the `reduce` column is 1 and where the sample
+    name is set will be processed.
     """
 
     def __init__(self, filename, data_folder=None, verbose=True,


### PR DESCRIPTION
Improve documentation and usability of batch reducer, including:

* adding an on-disk cache of reduced data so that the reducer can be restarted and plots can be made without requiring all data to be rereduced.

* making the list of reduced runs prettier by setting column types to `int` where appropriate and replacing `NaN` with blank entries.