### PR TITLE
BUG: encoding not specified on source code

### DIFF
--- a/refnx/reflect/structure.py
+++ b/refnx/reflect/structure.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import division
 from six.moves import UserList
 


### PR DESCRIPTION
structure.py cannot be imported into recent Python 2 as it uses non-ASCII characters but does not declare an encoding.

```
E     File .../refnx/reflect/structure.py", line 357                                                            
E   SyntaxError: Non-ASCII character '\xc2' in file .../refnx/reflect/structure.py on line 358, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details                   
```

(Initial assumption was that this was an Å from the thicknesses in L357 hence setting the encoding; it actually just a non-breaking space in "20 A", so perhaps fixing the file to be ASCII is better in this case)