### PR TITLE
ENH: memory optimized load_chain

### DIFF
--- a/refnx/analysis/curvefitter.py
+++ b/refnx/analysis/curvefitter.py
@@ -630,19 +630,46 @@ def load_chain(f):
         The loaded chain - `(nwalkers, nsteps, ndim)` or
         `(ntemps, nwalkers, nsteps, ndim)`
     """
-    chain = np.loadtxt(f)
-
     with possibly_open_file(f, 'r') as g:
         # read header
         header = g.readline()
-        match = re.match("#\s+(\d+),\s+(\d+)", header)
-        if match is not None:
-            walkers, ndim = map(int, match.groups())
+        expr = re.compile('(\d+)')
+        matches = expr.findall(header)
+        if matches:
+            if len(matches) == 3:
+                ntemps, nwalkers, ndim = map(int, matches)
+                chain_size = ntemps * nwalkers * ndim
+            elif len(matches) == 2:
+                ntemps = None
+                nwalkers, ndim = map(int, matches)
+                chain_size = nwalkers * ndim
         else:
             raise ValueError("Couldn't read header line of chain file")
 
-        chain = np.reshape(chain, (-1, walkers, ndim))
-        return np.swapaxes(chain, 0, -2)
+        # make an array that's the appropriate size
+        chain = np.empty((100, chain_size), dtype=float)
+
+        # expand memory as we go.
+        def chain_grow(chain):
+            new = np.empty((100, chain_size), dtype=float)
+            chain = np.concatenate((chain, new), axis=0)
+            return chain
+
+        for i, l in enumerate(g):
+            if i == np.size(chain, 0):
+                chain = chain_grow(chain)
+            chain[i] = np.fromstring(l, dtype=float, count=chain_size, sep=',')
+
+        # trim chain to the number of lines loaded
+        chain = chain[0: i + 1]
+
+        if ntemps is not None:
+            chain = np.reshape(chain, (-1, ntemps, nwalkers, ndim))
+        else:
+            chain = np.reshape(chain, (-1, nwalkers, ndim))
+        chain = np.swapaxes(chain, 0, -2)
+
+        return chain
 
 
 def process_chain(objective, chain, nburn=0, nthin=1, flatchain=False):

--- a/refnx/analysis/curvefitter.py
+++ b/refnx/analysis/curvefitter.py
@@ -658,7 +658,7 @@ def load_chain(f):
         for i, l in enumerate(g):
             if i == np.size(chain, 0):
                 chain = chain_grow(chain)
-            chain[i] = np.fromstring(l, dtype=float, count=chain_size, sep=',')
+            chain[i] = np.fromstring(l, dtype=float, count=chain_size, sep=' ')
 
         # trim chain to the number of lines loaded
         chain = chain[0: i + 1]

--- a/refnx/analysis/test/test_curvefitter.py
+++ b/refnx/analysis/test/test_curvefitter.py
@@ -276,7 +276,7 @@ class TestFitterGauss(object):
 
         # test loading the checkpoint
         chain = load_chain(checkpoint)
-        assert_equal(chain.shape, (f._nwalkers, 201, f.nvary))
+        assert_allclose(chain, f.chain)
 
     def test_best_unweighted(self):
         self.objective.use_weights = False


### PR DESCRIPTION
Loading a large emcee chain causes a *large* amount of memory to be used during np.loadtxt. Here the loading is optimized for memory footprint.