### PR TITLE
BUG: global_objective.lnprior model prior overcount

### DIFF
--- a/refnx/analysis/objective.py
+++ b/refnx/analysis/objective.py
@@ -704,7 +704,9 @@ class GlobalObjective(Objective):
         lnprior = 0.
         for objective in self.objectives:
             lnprior += objective.lnprior()
-            lnprior += objective.model.lnprob()
+            # shortcut if one of the priors is impossible
+            if not np.isfinite(lnprior):
+                return -np.inf
 
         return lnprior
 


### PR DESCRIPTION
The `GlobalObjective.lnprior` was including `Objective.model.lnprior` when `Objective.lnprior` was already including it. Thus the model prior was being counted twice. This bug was observed when `Objective.model.lnprior` was being called with impossible values - `Objective.lnprior` is supposed to shortcut to return `-np.inf` if any of the parameters are impossible.