### PR TITLE
ENH: add lnprob_extra function

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -36,7 +36,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
     'sphinx.ext.autosummary',
-    'numpydoc'
+    'sphinx.ext.napoleon'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -69,8 +69,9 @@ version = re.sub(r'\.dev-.*$', r'.dev', refnx.__version__)
 release = refnx.__version__
 
 intersphinx_mapping = {'py': ('http://docs.python.org/3', None),
-                       'numpy': ('http://docs.scipy.org/doc/numpy/', None),
-                       'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
+                       'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+                       'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+                       'matplotlib': ('http://matplotlib.org/', None),
                        }
 extlinks = {
     'scipydoc' : ('http://docs.scipy.org/doc/scipy/reference/generated/%s.html', ''),

--- a/refnx/analysis/curvefitter.py
+++ b/refnx/analysis/curvefitter.py
@@ -115,7 +115,7 @@ class CurveFitter(object):
 
     Parameters
     ----------
-    objective : Objective
+    objective : refnx.analysis.Objective
         The :class:`refnx.analysis.Objective` to be analysed.
     nwalkers : int, optional
         How many walkers you would like the sampler to have. Must be an
@@ -146,7 +146,7 @@ class CurveFitter(object):
         """
         Parameters
         ----------
-        objective : Objective
+        objective : refnx.analysis.Objective
             The :class:`refnx.analysis.Objective` to be analysed.
         nwalkers : int, optional
             How many walkers you would like the sampler to have. Must be an
@@ -596,13 +596,14 @@ class CurveFitter(object):
 
         Notes
         -----
-          If the `objective` supplies a `residuals` method then `least_squares`
+        If the `objective` supplies a `residuals` method then `least_squares`
         can be used. Otherwise the `nll` method of the `objective` is
         minimised. Use this method just before a sampling run.
-          If `self.objective.parameters` is a `Parameters` instance, then each
+        If `self.objective.parameters` is a `Parameters` instance, then each
         of the varying parameters has its value updated by the fit, and each
         `Parameter` has a `stderr` attribute which represents the uncertainty
         on the fit parameter.
+
         """
         _varying_parameters = self.objective.varying_parameters()
         init_pars = np.array(_varying_parameters)

--- a/refnx/analysis/model.py
+++ b/refnx/analysis/model.py
@@ -6,6 +6,7 @@ from refnx._lib.util import getargspec
 def fitfunc(f):
     """
     A decorator that can be used to say if something is a fitfunc.
+
     """
     f.fitfuncwraps = True
     return f
@@ -36,6 +37,7 @@ class Model(object):
     -----
     It is not necessary to supply `fitfunc` to create a `Model` *iff* you are
     inheriting `Model` and are also overriding `Model.model`.
+
     """
     def __init__(self, parameters, fitfunc=None, fcn_args=(), fcn_kwds=None):
         self._parameters = parameters
@@ -72,6 +74,7 @@ class Model(object):
         The interpretation of `x`, `p`, and `x_err` is up to the `fitfunc`
         supplied during construction of this object (or the overridden `model`
         method of this object).
+
         """
         return self.model(x, p=p, x_err=x_err)
 
@@ -98,6 +101,7 @@ class Model(object):
         The interpretation of `x`, `p`, and `x_err` is up to the `fitfunc`
         supplied during construction of this object (or the overridden `model`
         method of this object).
+
         """
         # self.fitfunc or this method has to understand the structure of
         # self.params.
@@ -121,9 +125,12 @@ class Model(object):
                                " the constructor")
 
     def lnprob(self):
-        # the model can add additional terms to it's log-probability. However,
-        # it should _not_ include lnprob from any of the parameters. That is
-        # calculated by objective.lnprior.
+        r"""
+        The model can add additional terms to it's log-probability. However,
+        it should _not_ include lnprob from any of the parameters. That is
+        calculated by objective.lnprior.
+
+        """
         return 0
 
     @property

--- a/refnx/analysis/objective.py
+++ b/refnx/analysis/objective.py
@@ -31,6 +31,7 @@ class BaseObjective(object):
         ----------
         pvals : np.ndarray
             Array containing the values to be tested.
+
         """
         self.parameters[:] = pvals
 
@@ -47,6 +48,7 @@ class BaseObjective(object):
         -------
         nll : float
             negative log-likelihood
+
         """
         vals = self.parameters
         if pvals is not None:
@@ -67,6 +69,7 @@ class BaseObjective(object):
         -------
         lnprior : float
             log-prior probability
+
         """
         vals = self.parameters
         if pvals is not None:
@@ -89,6 +92,7 @@ class BaseObjective(object):
         -------
         lnlike : float
             log-likelihood probability.
+
         """
         vals = self.parameters
         if pvals is not None:
@@ -114,6 +118,7 @@ class BaseObjective(object):
         -----
         The log probability is the sum is the sum of the log-prior and
         log-likelihood probabilities. Does not set the parameter attribute.
+
         """
         vals = self.parameters
         if pvals is not None:
@@ -131,6 +136,7 @@ class BaseObjective(object):
         -------
         varying_parameters : np.ndarray
             The parameters varying in this objective function.
+
         """
         return self.parameters
 
@@ -140,6 +146,7 @@ class BaseObjective(object):
         -------
         covar : np.ndarray
             The covariance matrix for the fitting system
+
         """
         _pvals = np.array(self.varying_parameters())
         hess = approx_hess2(_pvals, self.nll)
@@ -160,7 +167,7 @@ class Objective(BaseObjective):
         inherits `refnx.analysis.Model`.
     data : refnx.dataset.Data1D
         data to be analysed.
-    lnsigma : float or Parameter, optional
+    lnsigma : float or refnx.analysis.Parameter, optional
         the experimental uncertainty (`data.y_err`) is multiplied by
         `exp(lnsigma)`. Used when the experimental uncertainty is
         underestimated.
@@ -172,7 +179,7 @@ class Objective(BaseObjective):
         the model, data and data uncertainty are transformed by this
         function before calculating the likelihood/residuals. Has the
         signature `transform(data.x, y, y_err=None)`, returning the tuple
-        `transformed_y, transformed_y_err`.
+        (`transformed_y, transformed_y_err`).
     lnprob_extra : callable, optional
         user specifiable log-probability term. This contribution is in
         addition to the log-prior term of the `model` parameters, and
@@ -185,45 +192,11 @@ class Objective(BaseObjective):
     Notes
     -----
     For parallelisation `lnprob_extra` needs to be picklable.
+
     """
 
     def __init__(self, model, data, lnsigma=0, use_weights=True,
                  transform=None, lnprob_extra=None):
-        """
-        Parameters
-        ----------
-        model : refnx.analysis.Model
-            the generative model function. One can also provide an object that
-            inherits `refnx.analysis.Model`.
-        data : refnx.dataset.Data1D
-            data to be analysed.
-        lnsigma : float or Parameter, optional
-            the experimental uncertainty (`data.y_err`) is multiplied by
-            `exp(lnsigma)`. Used when the experimental uncertainty is
-            underestimated.
-        use_weights : bool
-            use experimental uncertainty in calculation of residuals and
-            lnlike, if available. If this is set to False, then you should also
-            set `self.lnsigma.vary = False`, it will have no effect on the fit.
-        transform : callable, optional
-            the model, data and data uncertainty are transformed by this
-            function before calculating the likelihood/residuals. Has the
-            signature `transform(data.x, y, y_err=None)`, returning the tuple
-            `transformed_y, transformed_y_err`.
-        lnprob_extra : callable, optional
-            user specifiable log-probability term. This contribution is in
-            addition to the log-prior term of the `model` parameters, and
-            `model.lnprob`, as well as the log-likelihood of the `data`. Has
-            signature:
-            `lnprob_extra(model, data)`. The `model` will already possess
-            updated parameters. Beware of including the same log-probability
-            terms more than once.
-
-        Notes
-        -----
-        For parallelisation `lnprob_extra` needs to be picklable.
-
-        """
         # lnsigma is a parameter for underestimated errors
         self.model = model
         # should be a Data1D instance
@@ -262,20 +235,15 @@ class Objective(BaseObjective):
     @property
     def weighted(self):
         """
-        Returns
-        -------
-        weighted : bool
-            Does the data have weights (`data.y_err`)?
+        **bool** does the data have weights (`data.y_err`)?
         """
         return self.data.weighted
 
     @property
     def npoints(self):
         """
-        Returns
-        -------
-        npoints : int
-            The number of points in the dataset.
+        **int** the number of points in the dataset.
+
         """
         return self.data.y.size
 
@@ -283,9 +251,9 @@ class Objective(BaseObjective):
         """
         Returns
         -------
-        varying_parameters : Parameters
-            A Parameters instance containing the varying Parameter objects
-            that are allowed to vary during the fit.
+        varying_parameters : refnx.analysis.Parameters
+            The varying Parameter objects allowed to vary during the fit.
+
         """
         # create and return a Parameters object because it has the
         # __array__ method, which allows one to quickly get numerical values.
@@ -318,12 +286,13 @@ class Objective(BaseObjective):
 
     def generative(self, pvals=None):
         """
-        Calculate the generative function associated with the model
+        Calculate the generative (dependent variable) function associated with
+        the model.
 
         Parameters
         ----------
-        pvals : np.ndarray
-            Parameter values for evaluation
+        pvals : array-like or refnx.analysis.Parameters
+            values for the varying or entire set of parameters
 
         Returns
         -------
@@ -338,13 +307,14 @@ class Objective(BaseObjective):
 
         Parameters
         ----------
-        pvals : np.ndarray
-            Parameter values for evaluation
+        pvals : array-like or refnx.analysis.Parameters
+            values for the varying or entire set of parameters
 
         Returns
         -------
         residuals : np.ndarray
             Residuals, `(data.y - model) / y_err`.
+
         """
         self.setp(pvals)
 
@@ -361,13 +331,14 @@ class Objective(BaseObjective):
 
         Parameters
         ----------
-        pvals : np.ndarray
-            Parameter values for evaluation
+        pvals : array-like or refnx.analysis.Parameters
+            values for the varying or entire set of parameters
 
         Returns
         -------
         chisqr : np.ndarray
             Chi-squared value, `np.sum(residuals**2)`.
+
         """
         # TODO reduced chisqr? include z-scores for parameters? DOF?
         self.setp(pvals)
@@ -377,12 +348,9 @@ class Objective(BaseObjective):
     @property
     def parameters(self):
         """
-        All the Parameters contained in the fitting system.
+        :class:`refnx.analysis.Parameters`, all the Parameters contained in the
+        fitting system.
 
-        Returns
-        -------
-        parameters : Parameters
-            Parameters instance containing all the Parameter(s)
         """
         if is_parameter(self.lnsigma):
             return self.lnsigma | self.model.parameters
@@ -395,8 +363,9 @@ class Objective(BaseObjective):
 
         Parameters
         ----------
-        pvals : np.ndarray
-            Array containing the values to be tested.
+        pvals : array-like or refnx.analysis.Parameters
+            values for the varying or entire set of parameters
+
         """
         if pvals is None:
             return
@@ -428,8 +397,8 @@ class Objective(BaseObjective):
 
         Parameters
         ----------
-        pvals : np.ndarray, optional
-            Numeric values for the Parameter's that are varying
+        pvals : array-like or refnx.analysis.Parameters
+            values for the varying or entire set of parameters
 
         Returns
         -------
@@ -438,20 +407,22 @@ class Objective(BaseObjective):
 
         Notes
         -----
-        The log-prior is calculated as;
+        The log-prior is calculated as:
 
         .. code-block:: python
 
-        lnprior = np.sum(param.lnprob() for param in self.varying_parameters())
-        lnprior += self.model.lnprob()
-        lnprior += self.lnprob_extra(self.model, self.data)
+            lnprior = np.sum(param.lnprob() for param in
+                             self.varying_parameters())
+            lnprior += self.model.lnprob()
+            lnprior += self.lnprob_extra(self.model, self.data)
 
         The major components of the log-prior probability are from the varying
-        parameters and the Model used to construct the Objective. The
+        parameters and the Model used to construct the Objective.
         `self.model.lnprob` should not include any contributions from
         `self.model.parameters` otherwise they'll be counted more than once.
         The same argument applies to the user specifiable `lnprob_extra`
         function.
+
         """
         self.setp(pvals)
 
@@ -476,8 +447,8 @@ class Objective(BaseObjective):
 
         Parameters
         ----------
-        pvals : np.ndarray, optional
-            Numeric values for the Parameter's that are varying
+        pvals : array-like or refnx.analysis.Parameters
+            values for the varying or entire set of parameters
 
         Returns
         -------
@@ -490,7 +461,7 @@ class Objective(BaseObjective):
 
         .. code-block:: python
 
-        lnlike = -0.5 * np.sum((y - model / y_err)**2 + np.log(y_err**2))
+            lnlike = -0.5 * np.sum((y - model / y_err)**2 + np.log(y_err**2))
 
         """
         self.setp(pvals)
@@ -520,13 +491,14 @@ class Objective(BaseObjective):
 
         Parameters
         ----------
-        pvals : np.ndarray
-            Array containing the values to be tested.
+        pvals : array-like or refnx.analysis.Parameters
+            values for the varying or entire set of parameters
 
         Returns
         -------
         nll : float
             negative log-likelihood
+
         """
         self.setp(pvals)
         return -self.lnlike()
@@ -537,8 +509,8 @@ class Objective(BaseObjective):
 
         Parameters
         ----------
-        pvals : np.ndarray, optional
-            Numeric values for the Parameter's that are varying
+        pvals : array-like or refnx.analysis.Parameters
+            values for the varying or entire set of parameters
 
         Returns
         -------
@@ -550,6 +522,7 @@ class Objective(BaseObjective):
         The overall log-probability is the sum of the log-prior and
         log-likelihood. The log-likelihood is not calculated if the log-prior
         is impossible (`lnprior == -np.inf`).
+
         """
         self.setp(pvals)
         lnprob = self.lnprior()
@@ -565,6 +538,12 @@ class Objective(BaseObjective):
     def covar(self):
         """
         Estimates the covariance matrix of the curvefitting system.
+
+        Returns
+        -------
+        covar : np.ndarray
+            Covariance matrix
+
         """
         _pvals = np.array(self.varying_parameters())
 
@@ -634,6 +613,7 @@ class Objective(BaseObjective):
         ------
         pvec : np.ndarray
             A randomly chosen parameter vector
+
         """
         chains = np.array([np.ravel(param.chain[..., nburn::nthin]) for param
                            in self.varying_parameters()
@@ -654,7 +634,7 @@ class Objective(BaseObjective):
 
     def plot(self, pvals=None):
         """
-        Plot the data/model
+        Plot the data/model.
 
         Parameters
         ----------
@@ -663,7 +643,9 @@ class Objective(BaseObjective):
 
         Returns
         -------
-        fig, ax
+        fig, ax : :class:`matplotlib.Figure`, :class:`matplotlib.Axes`
+            `matplotlib` figure and axes objects.
+
         """
         import matplotlib.pyplot as plt
 
@@ -690,14 +672,15 @@ class GlobalObjective(Objective):
     """
     Global Objective function for simultaneous fitting with
     `refnx.analysis.CurveFitter`
+
+    Parameters
+    ----------
+    objectives : list
+        list of :class:`refnx.analysis.Objective` objects
+
     """
 
     def __init__(self, objectives):
-        """
-        Parameters
-        ----------
-        objectives : list of Objective objects
-        """
         self.objectives = objectives
         weighted = []
         use_weights = []
@@ -721,22 +704,46 @@ class GlobalObjective(Objective):
 
     @property
     def use_weights(self):
+        """
+        **bool** is data weighting being used for all the objectives?
+        """
         return self._use_weights
 
     @property
     def weighted(self):
+        """
+        **bool** do all the datasets have y_err?
+
+        """
         return self._weighted
 
     @property
     def npoints(self):
+        """
+        **int** number of data points in all the objectives.
+
+        """
         npoints = 0
         for objective in self.objectives:
             npoints += objective.npoints
         return npoints
 
     def residuals(self, pvals=None):
-        # residuals in a globalfitting context are just the individual
-        # objective.residuals concatenated.
+        """
+        Concatenated residuals for each of the
+        :meth:`refnx.analysis.Objective.residuals`.
+
+        Parameters
+        ----------
+        pvals : array-like or refnx.analysis.Parameters
+            values for the varying or entire set of parameters
+
+        Returns
+        -------
+        residuals : np.ndarray
+            Concatenated :meth:`refnx.analysis.Objective.residuals`
+
+        """
         self.setp(pvals)
 
         residuals = []
@@ -748,6 +755,10 @@ class GlobalObjective(Objective):
 
     @property
     def parameters(self):
+        """
+        :class:`refnx.analysis.Parameters` associated with all the objectives.
+
+        """
         # TODO this is probably going to be slow.
         # cache and update strategy?
         p = Parameters(name='global fitting parameters')
@@ -763,19 +774,14 @@ class GlobalObjective(Objective):
 
         Parameters
         ----------
-        pvals : np.ndarray, optional
-            Numeric values for the Parameter's that are varying
+        pvals : array-like or refnx.analysis.Parameters, optional
+            values for the varying or entire set of parameters
 
         Returns
         -------
         lnprior : float
             log-prior probability
 
-        Notes
-        -----
-        The model attribute can also add extra terms to the log-prior if
-        needed, but it should not include any contributions from
-        `Objective.parameters` otherwise they'll be counted twice.
         """
         self.setp(pvals)
 
@@ -794,13 +800,14 @@ class GlobalObjective(Objective):
 
         Parameters
         ----------
-        pvals : np.ndarray, optional
-            Numeric values for the Parameter's that are varying
+        pvals : array-like or refnx.analysis.Parameters
+            values for the varying or entire set of parameters
 
         Returns
         -------
         lnlike : float
             log-likelihood probability
+
         """
         self.setp(pvals)
         lnlike = 0.

--- a/refnx/analysis/parameter.py
+++ b/refnx/analysis/parameter.py
@@ -341,12 +341,13 @@ def possibly_create_parameter(value, name=''):
     a Parameter instance.
 
     Parameters
-    ---------
-    value : float or Parameter
+    ----------
+    value : float or refnx.analysis.Parameter
 
     Returns
     -------
-    parameter : Parameter
+    parameter : refnx.analysis.Parameter
+
     """
     if is_parameter(value):
         return value

--- a/refnx/analysis/test/test_globalfitting.py
+++ b/refnx/analysis/test/test_globalfitting.py
@@ -53,24 +53,26 @@ class TestGlobalFitting(object):
         # smoke test for can the global fitting run?
         # also tests that global fitting gives same output as
         # normal fitting (for a single dataset)
-        self.model.scale.setp(vary=True, bounds=(0, 2))
-        self.model.bkg.setp(vary=True, bounds=(0, 8e-6))
-        self.structure[-1].rough.setp(vary=True, bounds=(0, 6))
-        self.sio2_l.thick.setp(vary=True, bounds=(0, 80))
-        self.polymer_l.thick.setp(bounds=(0, 400), vary=True)
-        self.polymer_l.sld.real.setp(vary=True, bounds=(0, 4))
+        self.model.scale.setp(vary=True, bounds=(0.1, 2))
+        self.model.bkg.setp(vary=True, bounds=(1e-10, 8e-6))
+        self.structure[-1].rough.setp(vary=True, bounds=(0.2, 6))
+        self.sio2_l.thick.setp(vary=True, bounds=(0.2, 80))
+        self.polymer_l.thick.setp(bounds=(0.01, 400), vary=True)
+        self.polymer_l.sld.real.setp(vary=True, bounds=(0.01, 4))
 
         self.objective.transform = Transform('logY')
 
-        g = CurveFitter(self.global_objective)
-        res_g = g.fit(method='differential_evolution', seed=1, maxiter=10)
+        with np.errstate(invalid='raise'):
+            g = CurveFitter(self.global_objective)
+            res_g = g.fit(method='differential_evolution', seed=1, maxiter=10)
 
-        f = CurveFitter(self.objective)
-        res_f = f.fit(method='differential_evolution', seed=1, maxiter=10)
+            f = CurveFitter(self.objective)
+            res_f = f.fit(method='differential_evolution', seed=1, maxiter=10)
 
-        # individual and global should give the same fit. Because we use DE
-        # there is no dependence on starting point, so long as we set a seed.
-        assert_almost_equal(res_g.x, res_f.x)
+            # individual and global should give the same fit. Because we use DE
+            # there is no dependence on starting point, so long as we set a
+            # seed.
+            assert_almost_equal(res_g.x, res_f.x)
 
     def test_multipledataset_corefinement(self):
         # test corefinement of three datasets

--- a/refnx/analysis/test/test_objective.py
+++ b/refnx/analysis/test/test_objective.py
@@ -171,16 +171,19 @@ class TestObjective(object):
         pickle.loads(pkl)
 
         # check the ForkingPickler as well.
-        pkl = ForkingPickler.dumps(self.objective)
-        pickle.loads(pkl)
+        if hasattr(ForkingPickler, 'dumps'):
+            pkl = ForkingPickler.dumps(self.objective)
+            pickle.loads(pkl)
 
         # can you pickle with an extra function present?
         self.objective.lnprob_extra = lnprob_extra
         pkl = pickle.dumps(self.objective)
         pickle.loads(pkl)
 
-        pkl = ForkingPickler.dumps(self.objective)
-        pickle.loads(pkl)
+        # check the ForkingPickler as well.
+        if hasattr(ForkingPickler, 'dumps'):
+            pkl = ForkingPickler.dumps(self.objective)
+            pickle.loads(pkl)
 
     def test_transform_pickle(self):
         # can you pickle the Transform object?

--- a/refnx/dataset/data1d.py
+++ b/refnx/dataset/data1d.py
@@ -55,6 +55,7 @@ class Data1D(object):
         Whether the y data has uncertainties
     metadata : dict
         Information that should be retained with the dataset.
+
     """
     def __init__(self, data=None, **kwds):
         self.filename = None
@@ -83,6 +84,7 @@ class Data1D(object):
     def __len__(self):
         """
         the number of points in the dataset.
+
         """
         return self.y.size
 
@@ -90,6 +92,7 @@ class Data1D(object):
     def data(self):
         """
         4-tuple containing the (x, y, y_err, x_err) data
+
         """
         return self.x, self.y, self.y_err, self.x_err
 
@@ -98,6 +101,7 @@ class Data1D(object):
         """
         4-tuple containing the (x, y, y_err, x_err) datapoints that are
         finite.
+
         """
         finite_loc = np.where(np.isfinite(self.y))
         return (self.x[finite_loc],
@@ -115,6 +119,7 @@ class Data1D(object):
         data_tuple : tuple
             2 to 4 member tuple containing the (x, y, y_err, x_err) data to
             specify the dataset. `y_err` and `x_err` are optional.
+
         """
         self.x = np.array(data_tuple[0], dtype=float)
         self.y = np.array(data_tuple[1], dtype=float)
@@ -139,6 +144,7 @@ class Data1D(object):
         ----------
         scalefactor : float
             The scalefactor to divide by.
+
         """
         self.y /= scalefactor
         self.y_err /= scalefactor
@@ -165,7 +171,8 @@ class Data1D(object):
         Notes
         -----
         Raises `ValueError` if there are no points in the overlap region and
-        `requires_splice` was True
+        `requires_splice` was True.
+
         """
         x, y, y_err, x_err = self.data
 
@@ -259,6 +266,7 @@ class Data1D(object):
         ----------
         f : file-handle or string
             File to save the dataset to.
+
         """
         np.savetxt(
             f, np.column_stack((self.x,
@@ -274,6 +282,7 @@ class Data1D(object):
         ----------
         f : file-handle or string
             File to load the dataset from.
+
         """
         # see if there are header rows
         with possibly_open_file(f, 'rb') as g:
@@ -302,6 +311,7 @@ class Data1D(object):
     def refresh(self):
         """
         Refreshes a previously loaded dataset.
+
         """
         if self.filename is not None:
             with open(self.filename) as f:
@@ -311,6 +321,7 @@ class Data1D(object):
         """
         Adds two datasets together. Splices the data and trims data in the
         overlap region.
+
         """
         ret = Data1D(self.data)
         ret.add_data(other.data, requires_splice=True, trim_trailing=True)
@@ -320,6 +331,7 @@ class Data1D(object):
         """
         radd of two datasets. Splices the data and trims data in the
         overlap region.
+
         """
         self.add_data(other.data, requires_splice=True, trim_trailing=True)
         return self
@@ -328,6 +340,7 @@ class Data1D(object):
         """
         iadd of two datasets. Splices the data and trims data in the
         overlap region.
+
         """
         self.add_data(other.data, requires_splice=True, trim_trailing=True)
         return self

--- a/refnx/reduce/bounded_splines.py
+++ b/refnx/reduce/bounded_splines.py
@@ -28,8 +28,9 @@ from scipy.interpolate import UnivariateSpline, RectBivariateSpline
 
 
 class BoundedUnivariateSpline(UnivariateSpline):
-    """
+    r"""
     1D spline that returns a constant for x outside the specified domain.
+
     """
     def __init__(self, x, y, fill_value=0.0, **kwargs):
         self.bnds = [x[0], x[-1]]
@@ -66,11 +67,11 @@ class BoundedUnivariateSpline(UnivariateSpline):
 
 
 class BoundedRectBivariateSpline(RectBivariateSpline):
-    """
+    r"""
     2D spline that returns a constant for x outside the specified domain.
 
-    Input
-    -----
+    Parameters
+    ----------
         x : array_like
             bin edges in x direction, length m+1
         y : array_like

--- a/refnx/reduce/peak_utils.py
+++ b/refnx/reduce/peak_utils.py
@@ -42,7 +42,8 @@ def centroid(y, x=None, dx=1.):
 
 
 def median(y, x=None, dx=1.):
-    '''Computes the median for the specified data.
+    r"""
+    Computes the median of the specified data.
 
     Parameters
     ----------
@@ -52,9 +53,10 @@ def median(y, x=None, dx=1.):
         The points at which y is sampled.
     Returns
     -------
-    (median, sd)
+    (median, sd) : float, float
         Centroid and standard deviation of the data.
-    '''
+
+    """
     yt = np.asfarray(y)
 
     if x is None:

--- a/refnx/reduce/platypusnexus.py
+++ b/refnx/reduce/platypusnexus.py
@@ -325,10 +325,12 @@ def datafile_number(fname):
     -------
     run_number : int
         The run number
+
     Examples
     --------
     >>> datafile_number('PLP0000708.nx.hdf')
     708
+
     """
 
     regex = re.compile(".*PLP([0-9]{7}).nx.hdf")
@@ -435,13 +437,14 @@ class PlatypusNexus(object):
         normalise : bool
             Normalise by the monitor counts.
         integrate : int
+            Specifies which scanpoints to use.
 
-            - integrate == -1
-              the spectrum is integrated over all the scanpoints.
-            - integrate >= 0
-              the individual spectra are calculated individually.
-              If `eventmode is not None`, or `event_filter is not None` then
-              integrate specifies which scanpoint to examine.
+             - integrate == -1
+               the spectrum is integrated over all the scanpoints.
+             - integrate >= 0
+               the individual spectra are calculated individually.
+               If `eventmode is not None`, or `event_filter is not None` then
+               integrate specifies which scanpoint to examine.
 
         eventmode : None or array_like
             If eventmode is `None` then the integrated detector image is used.
@@ -453,7 +456,7 @@ class PlatypusNexus(object):
             If eventmode has zero length (e.g. []), then a single time interval
             for the entire acquisition is used, [0, acquisition_time].  This
             would source the image from the eventmode file, rather than the
-            NeXUS file. Note: the two approaches will probably not give
+            NeXUS file. The two approaches will probably not give
             identical results, because the eventmode method adjusts the total
             acquisition time and beam monitor counts to the frame number of the
             last event detected (which may be quite different if the count rate
@@ -468,10 +471,14 @@ class PlatypusNexus(object):
             Options for finding specular peak position and peak standard
             deviation.
 
-                -1             - use `manual_beam_find`.
-                None           - use the automatic beam finder, falling back to
-                                 `manual_beam_find` if it's provided.
-                (float, float) - specify the peak and peak standard deviation.
+            - \-1
+               use `manual_beam_find`.
+            - None
+               use the automatic beam finder, falling back to
+               `manual_beam_find` if it's provided.
+            - (float, float)
+               specify the peak and peak standard deviation.
+
         peak_pos_tol : float
             Convergence tolerance for the beam position and width to be
             accepted from successive beam-finder calculations; see the
@@ -515,6 +522,7 @@ class PlatypusNexus(object):
                                                  t_bins=None,
                                                  y_bins=None,
                                                  x_bins=None)
+
             `loaded_events` is a 4-tuple of numpy arrays:
             `(f_events, t_events, y_events, x_events)`, where `f_events`
             contains the frame number for each neutron, landing at position
@@ -552,6 +560,7 @@ class PlatypusNexus(object):
         m_lambda, m_spec, m_spec_sd: np.ndarray
             Arrays containing the wavelength, specular intensity as a function
             of wavelength, standard deviation of specular intensity
+
         """
 
         # it can be advantageous to save processing time if the arguments
@@ -1137,6 +1146,7 @@ class PlatypusNexus(object):
                                                  t_bins=None,
                                                  y_bins=None,
                                                  x_bins=None)
+
             `loaded_events` is a 4-tuple of numpy arrays:
             `(f_events, t_events, y_events, x_events)`, where `f_events`
             contains the frame number for each neutron, landing at position
@@ -1159,6 +1169,7 @@ class PlatypusNexus(object):
         and finishes at 120s. The frame_bins are clipped to the total
         acquisition time if necessary.
         `frame_count` is how many frames went into making each detector image.
+
         """
         cat = self.cat
 

--- a/refnx/reflect/reflect_model.py
+++ b/refnx/reflect/reflect_model.py
@@ -24,21 +24,21 @@ _INTLIMIT = 3.5
 class ReflectModel(object):
     def __init__(self, structure, scale=1, bkg=1e-7, name='', dq=5.,
                  threads=0, quad_order=17):
-        """
+        r"""
         Parameters
         ----------
         structure : refnx.reflect.Structure
-            The interfacial structure
-        scale : float or Parameter, optional
+            The interfacial structure.
+        scale : float or refnx.analysis.Parameter, optional
             scale factor. All model values are multiplied by this value before
             the background is added. This is turned into a Parameter during the
             construction of this object.
-        bkg : float or Parameter, optional
+        bkg : float or refnx.analysis.Parameter, optional
             linear background added to all model values. This is turned into
             a Parameter during the construction of this object.
         name : str, optional
             Name of the Model
-        dq : float or Parameter, optional
+        dq : float or refnx.analysis.Parameter, optional
             If `dq == 0` then no resolution smearing is employed.
             If `dq` is a float or Parameter, then a constant dQ/Q resolution
             smearing is employed.  For 5% resolution smearing supply 5.
@@ -60,6 +60,7 @@ class ReflectModel(object):
             time. BUT it won't necessarily work across all samples. For
             example, 13 points may be fine for a thin layer, but will be
             atrocious at describing a multilayer with bragg peaks.
+
         """
         self.name = name
         self._parameters = None
@@ -82,15 +83,17 @@ class ReflectModel(object):
 
     @property
     def dq(self):
-        """
-        Returns
-        -------
-        dq : Parameter
-            If `dq.value == 0` then no resolution smearing is employed.
-            If `dq.value > 0`, then a constant dQ/Q resolution smearing is
-            employed.  For 5% resolution smearing supply 5. However, if
-            `x_err` is supplied to the `model` method, then that overrides any
-            setting reported here.
+        r"""
+        :class:`refnx.analysis.Parameter`
+
+            - `dq.value == 0`
+               no resolution smearing is employed.
+            - `dq.value > 0`
+               a constant dQ/Q resolution smearing is employed.  For 5%
+               resolution smearing supply 5. However, if `x_err` is supplied to
+               the `model` method, then that overrides any setting reported
+               here.
+
         """
         return self._dq
 
@@ -100,12 +103,10 @@ class ReflectModel(object):
 
     @property
     def scale(self):
-        """
-        Returns
-        -------
-        scale : Parameter
-            scale factor. All model values are multiplied by this value before
-            the background is added.
+        r"""
+        :class:`refnx.analysis.Parameter` - all model values are multiplied by
+        this value before the background is added.
+
         """
         return self._scale
 
@@ -115,11 +116,10 @@ class ReflectModel(object):
 
     @property
     def bkg(self):
-        """
-        Returns
-        -------
-        bkg : Parameter
-            linear background added to all model values.
+        r"""
+        :class:`refnx.analysis.Parameter` - linear background added to all
+        model values.
+
         """
         return self._bkg
 
@@ -128,14 +128,14 @@ class ReflectModel(object):
         self._bkg.value = value
 
     def model(self, x, p=None, x_err=None):
-        """
+        r"""
         Calculate the reflectivity of this model
 
         Parameters
         ----------
         x : float or np.ndarray
             q values for the calculation.
-        p : Parameters instance, optional
+        p : refnx.analysis.Parameter, optional
             parameters required to calculate the model
         x_err : np.ndarray
             dq resolution smearing values for the dataset being considered.
@@ -143,6 +143,7 @@ class ReflectModel(object):
         Returns
         -------
         reflectivity : np.ndarray
+
         """
         if p is not None:
             self.parameters.pvals = np.array(p)
@@ -158,7 +159,7 @@ class ReflectModel(object):
                             quad_order=self.quad_order)
 
     def lnprob(self):
-        """
+        r"""
         Additional log-probability terms for the reflectivity model. Do not
         include log-probability terms for model parameters, these are
         automatically calculated elsewhere.
@@ -167,16 +168,16 @@ class ReflectModel(object):
         -------
         lnprob : float
             log-probability of structure.
+
         """
         return self.structure.lnprob()
 
     @property
     def structure(self):
-        """
-        Returns
-        -------
-        structure : Structure
-            Structure objects describe the interface of a reflectometry sample.
+        r"""
+        :class:`refnx.reflect.Structure` - object describing the interface of
+        a reflectometry sample.
+
         """
         return self._structure
 
@@ -191,11 +192,10 @@ class ReflectModel(object):
 
     @property
     def parameters(self):
-        """
-        Returns
-        -------
-        parameters : `Parameters`
-            The Parameters associated with this model.
+        r"""
+        :class:`refnx.analysis.Parameters` - parameters associated with this
+        model.
+
         """
         self.structure = self._structure
         return self._parameters
@@ -217,21 +217,33 @@ def reflectivity(q, slabs, scale=1., bkg=0., dq=5., quad_order=17,
         coefficients required for the calculation, has shape (2 + N, 4),
         where N is the number of layers
 
-        slabs[0, 0] - ignored
-        slabs[N, 0] - thickness of layer N
-        slabs[N+1, 0] - ignored
+        - slabs[0, 0]
+           ignored
+        - slabs[N, 0]
+           thickness of layer N
+        - slabs[N+1, 0]
+           ignored
 
-        slabs[0, 1] - SLD_real of fronting (/1e-6 Angstrom**-2)
-        slabs[N, 1] - SLD_real of layer N (/1e-6 Angstrom**-2)
-        slabs[-1, 1] - SLD_real of backing (/1e-6 Angstrom**-2)
+        - slabs[0, 1]
+           SLD_real of fronting (/1e-6 Angstrom**-2)
+        - slabs[N, 1]
+           SLD_real of layer N (/1e-6 Angstrom**-2)
+        - slabs[-1, 1]
+           SLD_real of backing (/1e-6 Angstrom**-2)
 
-        slabs[0, 2] - SLD_imag of fronting (/1e-6 Angstrom**-2)
-        slabs[N, 2] - iSLD_imag of layer N (/1e-6 Angstrom**-2)
-        slabs[-1, 2] - iSLD_imag of backing (/1e-6 Angstrom**-2)
+        - slabs[0, 2]
+           SLD_imag of fronting (/1e-6 Angstrom**-2)
+        - slabs[N, 2]
+           iSLD_imag of layer N (/1e-6 Angstrom**-2)
+        - slabs[-1, 2]
+           iSLD_imag of backing (/1e-6 Angstrom**-2)
 
-        slabs[0, 3] - ignored
-        slabs[N, 3] - roughness between layer N-1/N
-        slabs[-1, 3] - roughness between backing and layer N
+        - slabs[0, 3]
+           ignored
+        - slabs[N, 3]
+           roughness between layer N-1/N
+        - slabs[-1, 3]
+           roughness between backing and layer N
 
     scale : float
         scale factor. All model values are multiplied by this value before
@@ -239,20 +251,21 @@ def reflectivity(q, slabs, scale=1., bkg=0., dq=5., quad_order=17,
     bkg : float
         linear background added to all model values.
     dq : float or np.ndarray, optional
-        If `dq == 0` then no resolution smearing is employed.
-        If dq is a float, then a constant dQ/Q resolution smearing is
-        employed.  For 5% resolution smearing supply 5.
-        If `dq` is the same shape as q, then the array contains the
-        FWHM of a Gaussian approximated resolution kernel. Point by point
-        resolution smearing is employed.  Use this option if dQ/Q varies
-        across your dataset.
-        If `dq.ndim == q.ndim + 2` and
-        `q.shape == dq[..., -3].shape` then an individual resolution
-        kernel is applied to each measurement point.  This resolution
-        kernel is a probability distribution function (PDF). `dqvals` will
-        have the shape (qvals.shape, M, 2).  There are `M` points in the
-        kernel. `dq[..., 0]` holds the q values for the kernel,
-        `dq[..., 1]` gives the corresponding probability.
+        - `dq == 0`
+           no resolution smearing is employed.
+        - `dq` is a float
+           a constant dQ/Q resolution smearing is employed.  For 5% resolution
+           smearing supply 5.
+        - `dq` is the same shape as q
+           the array contains the FWHM of a Gaussian approximated resolution
+           kernel. Point by point resolution smearing is employed.  Use this
+           option if dQ/Q varies across your dataset.
+        - `dq.ndim == q.ndim + 2` and `q.shape == dq[..., -3].shape`
+           an individual resolution kernel is applied to each measurement
+           point. This resolution kernel is a probability distribution function
+           (PDF). `dqvals` will have the shape (qvals.shape, M, 2).  There are
+           `M` points in the kernel. `dq[..., 0]` holds the q values for the
+           kernel, `dq[..., 1]` gives the corresponding probability.
     quad_order: int, optional
         the order of the Gaussian quadrature polynomial for doing the
         resolution smearing. default = 17. Don't choose less than 13. If
@@ -268,6 +281,7 @@ def reflectivity(q, slabs, scale=1., bkg=0., dq=5., quad_order=17,
         module. The option is ignored if using the pure python calculator,
         ``_reflect``. If `threads == 0` then all available processors are
         used.
+
     """
     # constant dq/q smearing
     if isinstance(dq, numbers.Real) and float(dq) == 0:

--- a/refnx/reflect/reflect_model.py
+++ b/refnx/reflect/reflect_model.py
@@ -22,46 +22,49 @@ _INTLIMIT = 3.5
 
 
 class ReflectModel(object):
+    r"""
+    Parameters
+    ----------
+    structure : refnx.reflect.Structure
+        The interfacial structure.
+    scale : float or refnx.analysis.Parameter, optional
+        scale factor. All model values are multiplied by this value before
+        the background is added. This is turned into a Parameter during the
+        construction of this object.
+    bkg : float or refnx.analysis.Parameter, optional
+        linear background added to all model values. This is turned into
+        a Parameter during the construction of this object.
+    name : str, optional
+        Name of the Model
+    dq : float or refnx.analysis.Parameter, optional
+
+        - `dq == 0` then no resolution smearing is employed.
+        - `dq` is a float or refnx.analysis.Parameter
+           a constant dQ/Q resolution smearing is employed.  For 5% resolution
+           smearing supply 5.
+
+        However, if `x_err` is supplied to the `model` method, then that
+        overrides any setting given here. This value is turned into
+        a Parameter during the construction of this object.
+    threads: int, optional
+        Specifies the number of threads for parallel calculation. This
+        option is only applicable if you are using the ``_creflect``
+        module. The option is ignored if using the pure python calculator,
+        ``_reflect``. If `threads == 0` then all available processors are
+        used.
+    quad_order: int, optional
+        the order of the Gaussian quadrature polynomial for doing the
+        resolution smearing. default = 17. Don't choose less than 13. If
+        quad_order == 'ultimate' then adaptive quadrature is used. Adaptive
+        quadrature will always work, but takes a _long_ time (2 or 3 orders
+        of magnitude longer). Fixed quadrature will always take a lot less
+        time. BUT it won't necessarily work across all samples. For
+        example, 13 points may be fine for a thin layer, but will be
+        atrocious at describing a multilayer with bragg peaks.
+
+    """
     def __init__(self, structure, scale=1, bkg=1e-7, name='', dq=5.,
                  threads=0, quad_order=17):
-        r"""
-        Parameters
-        ----------
-        structure : refnx.reflect.Structure
-            The interfacial structure.
-        scale : float or refnx.analysis.Parameter, optional
-            scale factor. All model values are multiplied by this value before
-            the background is added. This is turned into a Parameter during the
-            construction of this object.
-        bkg : float or refnx.analysis.Parameter, optional
-            linear background added to all model values. This is turned into
-            a Parameter during the construction of this object.
-        name : str, optional
-            Name of the Model
-        dq : float or refnx.analysis.Parameter, optional
-            If `dq == 0` then no resolution smearing is employed.
-            If `dq` is a float or Parameter, then a constant dQ/Q resolution
-            smearing is employed.  For 5% resolution smearing supply 5.
-            However, if `x_err` is supplied to the `model` method, then that
-            overrides any setting given here. This value is turned into
-            a Parameter during the construction of this object.
-        threads: int, optional
-            Specifies the number of threads for parallel calculation. This
-            option is only applicable if you are using the ``_creflect``
-            module. The option is ignored if using the pure python calculator,
-            ``_reflect``. If `threads == 0` then all available processors are
-            used.
-        quad_order: int, optional
-            the order of the Gaussian quadrature polynomial for doing the
-            resolution smearing. default = 17. Don't choose less than 13. If
-            quad_order == 'ultimate' then adaptive quadrature is used. Adaptive
-            quadrature will always work, but takes a _long_ time (2 or 3 orders
-            of magnitude longer). Fixed quadrature will always take a lot less
-            time. BUT it won't necessarily work across all samples. For
-            example, 13 points may be fine for a thin layer, but will be
-            atrocious at describing a multilayer with bragg peaks.
-
-        """
         self.name = name
         self._parameters = None
         self.threads = threads

--- a/refnx/reflect/structure.py
+++ b/refnx/reflect/structure.py
@@ -65,8 +65,13 @@ class Structure(UserList):
             raise ValueError("solvent must either be the fronting or backing"
                              " medium")
 
+        #: **str** specifies whether `backing` or `fronting` semi-infinite
+        #: medium is used to solvate components.
         self.solvent = solvent
         self._reverse_structure = bool(reverse_structure)
+        #: **float** if contract > 0 then an attempt to contract/shrink the
+        #: slab representation is made. Use larger values for coarser profiles
+        #: (and vice versa). A typical starting value to try might be 1.0.
         self.contract = contract
         # self._parameters = Parameters(name=name)
 
@@ -99,6 +104,11 @@ class Structure(UserList):
 
     @property
     def reverse_structure(self):
+        """
+        **bool**  if `True` then the slab representation produced by
+        :meth:`Structure.slabs` is reversed. The sld profile and calculated
+        reflectivity will correspond to this reversed structure.
+        """
         return bool(self._reverse_structure)
 
     @reverse_structure.setter
@@ -327,7 +337,11 @@ class Structure(UserList):
 
     @property
     def parameters(self):
-        # return self._parameters
+        r"""
+        :class:`refnx.analysis.Parameters`, all the parameters associated with
+        this structure.
+
+        """
         p = Parameters(name='Structure - {0}'.format(self.name))
         p.extend([component.parameters for component in self.components])
         return p


### PR DESCRIPTION
The log-prior consists of the varying parameter log-probabilities, the model log-probability (which shouldn't include any parameter log-probs).
The log-likelihood consists of the model vs data log-probability.

However, there may be an extra term which is difficult for the user to add via any of the above.
For example, the user may not be able to amend the model code. This PR adds the option of providing a `lnprob_extra` function which is folder into the log-prior term.