### PR TITLE
ENH: use rv to set bounds

### DIFF
--- a/refnx/analysis/parameter.py
+++ b/refnx/analysis/parameter.py
@@ -437,7 +437,8 @@ class Parameter(BaseParameter):
         elif hasattr(bounds, '__len__') and len(bounds) == 2:
             self.range(*bounds)
         else:
-            raise ValueError("Can't set bounds with the value provided.")
+            rv = PDF(bounds)
+            self._bounds = rv
 
     def valid(self, val):
         return self.bounds.valid(val)

--- a/refnx/analysis/test/test_parameter.py
+++ b/refnx/analysis/test/test_parameter.py
@@ -74,6 +74,9 @@ class TestParameter(object):
         assert_equal(x.bounds.ub, np.inf)
         assert_equal(x.lnprob(), 0)
 
+        x.setp(bounds=norm(0, 1))
+        assert_almost_equal(x.lnprob(1), norm.logpdf(1, 0, 1))
+
     def test_range(self):
         x = Parameter(0.)
         x.range(-1, 1.)


### PR DESCRIPTION
Use rv to set bounds.
e.g.
```
x.setp(bound=norm(0, 1))
```