### PR TITLE
ENH: solvation now done by specific solvent

### DIFF
--- a/examples/analytical_profiles/brushes/brush.py
+++ b/examples/analytical_profiles/brushes/brush.py
@@ -105,6 +105,12 @@ class FreeformVFPextent(Component):
         direction that is requested.
     microslab_max_thickness : float
         Thickness of microslicing of spline for reflectivity calculation.
+
+    Notes
+    -----
+    When this component is part of a ``reflect.Structure``, then the
+    ``Structure.solvent`` attribute needs to be set, in order for solvation
+    of the brush to occur.
     """
 
     def __init__(self, extent, vf, dz, polymer_sld, solvent, name='',
@@ -456,6 +462,9 @@ class FreeformVFPgamma(Component):
 
     Notes
     -----
+    When this component is part of a ``reflect.Structure``, then the
+    ``Structure.solvent`` attribute needs to be set, in order for solvation
+    of the brush to occur.
     The total extent of the spline region is calculated such that the total
     profile area is the same as `gamma`. The log-probability of this model
     is -np.inf if the extent of the spline region is less than, or equal to,

--- a/refnx/reflect/spline.py
+++ b/refnx/reflect/spline.py
@@ -32,8 +32,8 @@ class Spline(Component):
             The Component to the left of this Spline region.
         right : refnx.reflect.Component
             The Component to the right of this Spline region.
-        solvent : refnx.reflect.Slab
-            A Slab instance representing the solvent
+        solvent : refnx.reflect.SLD
+            An SLD instance representing the solvent
         name : str
             Name of component
         interpolator : scipy.interpolate Univariate Interpolator, optional
@@ -70,7 +70,7 @@ class Spline(Component):
         self.name = name
         self.left_slab = left
         self.right_slab = right
-        self.solvent_slab = solvent
+        self.solvent = solvent
         self.microslab_max_thickness = microslab_max_thickness
 
         self.extent = (
@@ -116,11 +116,11 @@ class Spline(Component):
 
         left_sld = Structure.overall_sld(
             np.atleast_2d(self.left_slab.slabs[-1]),
-            self.solvent_slab.slabs)[..., 1]
+            self.solvent)[..., 1]
 
         right_sld = Structure.overall_sld(
             np.atleast_2d(self.right_slab.slabs[0]),
-            self.solvent_slab.slabs)[..., 1]
+            self.solvent)[..., 1]
 
         if self.zgrad:
             zeds = np.concatenate([[-1.1, 0 - EPS], zeds, [1 + EPS, 2.1]])
@@ -173,7 +173,7 @@ class Spline(Component):
         p.extend([self.extent, self.dz, self.vs,
                   self.left_slab.parameters,
                   self.right_slab.parameters,
-                  self.solvent_slab.parameters])
+                  self.solvent.parameters])
         return p
 
     def lnprob(self):

--- a/refnx/reflect/test/test_spline.py
+++ b/refnx/reflect/test/test_spline.py
@@ -11,7 +11,7 @@ class TestReflect(object):
     def setup_method(self):
         self.left = SLD(1.5)(10, 3)
         self.right = SLD(2.5)(10, 3)
-        self.solvent = SLD(10)(0, 3)
+        self.solvent = SLD(10)
 
     def test_spline_smoke(self):
         # smoke test to make Spline at least gives us something
@@ -53,7 +53,7 @@ class TestReflect(object):
         # check that the spline responds if it's a vfsolve that changes
         self.left.vfsolv.value = 0.5
         assert_almost_equal(Structure.overall_sld(self.left.slabs,
-                                                  self.solvent.slabs)[0, 1],
+                                                  self.solvent)[0, 1],
                             6.)
         assert_almost_equal(a(0), 6.)
 

--- a/refnx/reflect/test/test_structure.py
+++ b/refnx/reflect/test/test_structure.py
@@ -26,6 +26,7 @@ class TestStructure(object):
                                              [0, 6.36, 0, 4, 0]]))
 
         # slabs have solvent penetration
+        self.s.solvent = self.d2o
         self.s[1] = SLD(3.47 + 1j, name='sio2')(100, 5)
         self.s[1].vfsolv.value = 0.9
         sld = 6.36 * 0.9 + 0.1 * 3.47
@@ -66,7 +67,7 @@ class TestStructure(object):
     def test_slab_addition(self):
         # The slabs property for the main Structure component constructs
         # the overall slabs by concatenating Component slabs. It preallocates
-        # memory to prevent repeated memory allocations. THis checks that the
+        # memory to prevent repeated memory allocations. This checks that the
         # slab concatenation is correct.
 
         si = SLD(2.07)
@@ -76,7 +77,7 @@ class TestStructure(object):
         d2o_layer = d2o(0, 3)
         polymer_layer = polymer(20, 3)
         a = Spline(400, [4, 5.9],
-                   [0.2, .4], polymer_layer, d2o_layer, d2o_layer, zgrad=True)
+                   [0.2, .4], polymer_layer, d2o_layer, d2o, zgrad=True)
         film = si | sio2(10, 3) | polymer_layer | a | d2o_layer
         film.sld_profile()
 


### PR DESCRIPTION
@arm61 @llimeht @igresh @llimeht 
This is a change that significantly alters behaviour. When a `Structure` is created one used to be able to use `fronting` or `backing` to define how you wanted to solvate the structure. 

Now the string arguments have been removed, and you have to supply an `SLD` instance.
If you don't supply an SLD instance then the SLD of the backing medium is used by default (`Structure[-1].slabs[-1]`).
This should be back compatible for those that automatically use backing medium for solvation, but those who use fronting medium for solvation need to supply an `SLD` instance.
The PR has the advantage that an arbitrary SLD can be used for solvation, it doesn't have to be the fronting or backing media.