### PR TITLE
ENH: mixed_model

### DIFF
--- a/refnx/reflect/reflect_model.py
+++ b/refnx/reflect/reflect_model.py
@@ -631,7 +631,8 @@ class MixedReflectModel(object):
             tscales = [1 / len(structures)] * len(structures)
 
         for scale in tscales:
-            pscales.append(possibly_create_parameter(scale, name='scale'))
+            p_scale = possibly_create_parameter(scale, name='scale')
+            pscales.append(p_scale)
 
         self._scales = pscales
         self._bkg = possibly_create_parameter(bkg, name='bkg')
@@ -764,8 +765,6 @@ class MixedReflectModel(object):
 
         self._parameters = Parameters(name=self.name)
         self._parameters.append([p])
-
-        for structure in self._structures:
-            self._parameters.append(structure.parameters)
-
+        self._parameters.extend([structure.parameters for structure
+                                 in self._structures])
         return self._parameters


### PR DESCRIPTION
Adds the ability to add create a mixed area reflectivity model.
For example, you may have a surface that is 50% covered by a monolayer, and 50% of a surface that isn't. You can create a `Structure` for each of those areas, and combine them together in a `MixedReflectModel`, with a scale factor for each of the two structures. THe scale factors are used to calculate the relative contribution of each area.