### PR TITLE
MAINT: catalogue kwd change

### DIFF
--- a/refnx/reduce/platypusnexus.py
+++ b/refnx/reduce/platypusnexus.py
@@ -53,7 +53,7 @@ spectrum_template = """<?xml version="1.0"?>
 </REFroot>"""
 
 
-def catalogue(start, stop, path=None):
+def catalogue(start, stop, data_folder=None):
     """
     Extract interesting information from Platypus NeXUS files.
 
@@ -63,7 +63,7 @@ def catalogue(start, stop, path=None):
         start cataloguing from this run number.
     stop : int
         stop cataloguing at this run number
-    path : str, optional
+    data_folder : str, optional
         path specifying location of NeXUS files
 
     Returns
@@ -77,12 +77,12 @@ def catalogue(start, stop, path=None):
     run_number = []
     d = {key: [] for key in info}
 
-    if path is None:
-        path = '.'
+    if data_folder is None:
+        data_folder = '.'
 
     for i in range(start, stop + 1):
         try:
-            pn = PlatypusNexus(os.path.join(path, number_datafile(i)))
+            pn = PlatypusNexus(os.path.join(data_folder, number_datafile(i)))
         except OSError:
             continue
 

--- a/refnx/reduce/reduce.py
+++ b/refnx/reduce/reduce.py
@@ -78,7 +78,7 @@ class PlatypusReduce(object):
     >>> datasets, reduced = PlatypusReduce('PLP0000711.nx.hdf',
     ...                                    reflect='PLP0000711.nx.hdf',
     ...                                    rebin_percent=2)
-    
+
     """
 
     def __init__(self, direct, reflect=None, data_folder=None, scale=1.,
@@ -175,7 +175,9 @@ class PlatypusReduce(object):
         >>> from refnx.reduce import PlatypusReduce
         >>> # set up with a direct beam
         >>> reducer = PlatypusReduce('PLP0000711.nx.hdf')
-        >>> datasets, reduction = reducer.reduce('PLP0000708.nx.hdf', rebin_percent=3.)
+        >>> datasets, reduction = reducer.reduce('PLP0000708.nx.hdf',
+        ...                                      rebin_percent=3.)
+
         """
         reflect_keywords = kwds.copy()
         direct_keywords = kwds.copy()

--- a/refnx/reduce/reduce.py
+++ b/refnx/reduce/reduce.py
@@ -70,6 +70,15 @@ class PlatypusReduce(object):
     Returns
     -------
     None
+
+    Examples
+    --------
+
+    >>> from refnx.reduce import PlatypusReduce
+    >>> datasets, reduced = PlatypusReduce('PLP0000711.nx.hdf',
+    ...                                    reflect='PLP0000711.nx.hdf',
+    ...                                    rebin_percent=2)
+    
     """
 
     def __init__(self, direct, reflect=None, data_folder=None, scale=1.,
@@ -119,6 +128,10 @@ class PlatypusReduce(object):
 
         Returns
         -------
+        datasets, reduction : tuple
+
+        datasets : sequence of ReflectDataset
+
         reduction : dict
             Contains the following entries:
 
@@ -162,7 +175,7 @@ class PlatypusReduce(object):
         >>> from refnx.reduce import PlatypusReduce
         >>> # set up with a direct beam
         >>> reducer = PlatypusReduce('PLP0000711.nx.hdf')
-        >>> reduction = reducer.reduce('PLP0000708.nx.hdf', rebin_percent=3.)
+        >>> datasets, reduction = reducer.reduce('PLP0000708.nx.hdf', rebin_percent=3.)
         """
         reflect_keywords = kwds.copy()
         direct_keywords = kwds.copy()
@@ -196,8 +209,8 @@ class PlatypusReduce(object):
         self.reflected_beam.process(**reflect_keywords)
 
         self.save = save
-        reduction = self._reduce_single_angle(scale)
-        return reduction
+        dataset, reduction = self._reduce_single_angle(scale)
+        return dataset, reduction
 
     def data(self, scanpoint=0):
         """
@@ -445,14 +458,16 @@ class PlatypusReduce(object):
             self.reflected_beam.datafile_number)
 
         fnames = []
+        datasets = []
+        datafilename = self.reflected_beam.datafilename
+        datafilename = os.path.basename(datafilename.split('.nx.hdf')[0])
+
+        for i in range(n_spectra):
+            data_tup = self.data(scanpoint=i)
+            datasets.append(ReflectDataset(data_tup))
+
         if self.save:
-            datafilename = self.reflected_beam.datafilename
-            datafilename = os.path.basename(datafilename.split('.nx.hdf')[0])
-
-            for i in range(n_spectra):
-                data_tup = self.data(scanpoint=i)
-                dataset = ReflectDataset(data_tup)
-
+            for dataset in datasets:
                 fname = '{0}_{1}.dat'.format(datafilename, i)
                 fnames.append(fname)
                 with open(fname, 'wb') as f:
@@ -464,7 +479,7 @@ class PlatypusReduce(object):
                                      start_time=reduction['start_time'][i])
 
         reduction['fname'] = fnames
-        return deepcopy(reduction)
+        return datasets, deepcopy(reduction)
 
 
 def reduce_stitch(reflect_list, direct_list, background_list=None,

--- a/refnx/reduce/test/test_platypusnexus.py
+++ b/refnx/reduce/test/test_platypusnexus.py
@@ -217,12 +217,13 @@ class TestPlatypusNexus(object):
         # it should also be reduceable
         reducer = PlatypusReduce(os.path.join(self.pth,
                                               'PLP0000711.nx.hdf'))
-        reduced = reducer.reduce(os.path.join(os.getcwd(),
-                                              'ADD_PLP0000708.nx.hdf'))
+        datasets, reduced = reducer.reduce(os.path.join(os.getcwd(),
+                                           'ADD_PLP0000708.nx.hdf'))
         assert_('y' in reduced)
 
         # the error bars should be smaller
-        reduced2 = reducer.reduce(os.path.join(self.pth, 'PLP0000708.nx.hdf'))
+        datasets2, reduced2 = reducer.reduce(os.path.join(self.pth,
+                                                          'PLP0000708.nx.hdf'))
 
         assert_(np.all(reduced['y_err'] < reduced2['y_err']))
 


### PR DESCRIPTION
catalogue keyword changed from `path` to `data_folder` for consistency.

`PlatypusReduce.reduce` now returns a list of datasets, as well as the original dict that was returned.