### PR TITLE
MAINT: vendorize emcee3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,11 +37,10 @@ before_install:
     - conda create --yes -n conda-refnx python=$PY
     - source activate conda-refnx
     - conda install --yes numpy scipy h5py cython pandas xlrd flake8 six pytest
-    - pip install emcee uncertainties ptemcee
+    - pip install uncertainties ptemcee
 
     # gradually expand flake8 to all of codebase
     - flake8 --ignore=F401 refnx
-
 
 install:
     - python setup.py install

--- a/INSTALL_CONTRIBUTE.md
+++ b/INSTALL_CONTRIBUTE.md
@@ -1,12 +1,24 @@
 # refnx - Installation and Development Instructions
 
-refnx is a python package for analysis of neutron and X-ray reflectometry data. It can also be used as a generalised curvefitting tool. It uses Markov Chain Monte Carlo to obtain posterior distributions for curvefitting problems.
+refnx is a python package for analysis of neutron and X-ray reflectometry data.
+It can also be used as a generalised curvefitting tool. It uses Markov Chain
+Monte Carlo to obtain posterior distributions for curvefitting problems.
 
 --------------
 # Installation
 
-*refnx* has been tested on Python 2.7, 3.4, 3.5 and 3.6. It requires the *numpy, scipy, cython, pandas, emcee* packages to work. Additional features require the *pytest, h5py, xlrd, uncertainties, ptemcee* packages. To build the bleeding edge code you will need to have access to a C-compiler to build a couple of Python extensions. C-compilers should be installed on Linux. On OSX you will need to install Xcode and the command line tools. On Windows you will need to install the correct [Visual Studio compiler][Visual-studio-compiler] for your Python version.
-  
+*refnx* has been tested on Python 2.7, 3.4, 3.5 and 3.6. It requires the *numpy,
+scipy, cython, pandas, emcee* packages to work. Additional features require the
+*pytest, h5py, xlrd, uncertainties, ptemcee* packages. To build the bleeding edge
+code you will need to have access to a C-compiler to build a couple of Python
+extensions. C-compilers should be installed on Linux. On OSX you will need to
+install Xcode and the command line tools. On Windows you will need to install
+the correct [Visual Studio compiler][Visual-studio-compiler] for your Python version.
+
+In the current version of *refnx* the *emcee* package is vendored by *refnx*. That
+is, *refnx* possesses it's own private copy of the package, and there is no need to
+install the *emcee* package separately.
+
 ## Installation into a *conda* environment
 
 Perhaps the easiest way to create a scientific computing environment is to use the [miniconda][miniconda] package manager. Once *conda* has been installed the first step is to create a *conda* environment.
@@ -26,7 +38,7 @@ Perhaps the easiest way to create a scientific computing environment is to use t
   activate refnx
   ```
   3) Install the remaining dependencies:
-  ```pip install emcee uncertainties ptemcee```
+  ```pip install uncertainties ptemcee```
  
 ### Installing into a conda environment from source
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -96,7 +96,7 @@ install:
 
     # Configure the VM.
     - cmd: call conda.exe install -n root --yes --quiet obvious-ci
-    - cmd: call conda.exe install -n root --yes --quiet numpy scipy h5py xlrd pandas cython six pytest toolchain emcee uncertainties
+    - cmd: call conda.exe install -n root --yes --quiet numpy scipy h5py xlrd pandas cython six pytest toolchain uncertainties
 
 build_script:
     # Build the compiled extension

--- a/refnx/_lib/emcee/LICENSE
+++ b/refnx/_lib/emcee/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2010-2017 Daniel Foreman-Mackey & contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/refnx/_lib/emcee/__init__.py
+++ b/refnx/_lib/emcee/__init__.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, absolute_import
+
+__version__ = "3.0.0.dev0"
+__bibtex__ = """
+@article{emcee,
+   author = {{Foreman-Mackey}, D. and {Hogg}, D.~W. and {Lang}, D. and
+             {Goodman}, J.},
+    title = {emcee: The MCMC Hammer},
+  journal = {PASP},
+     year = 2013,
+   volume = 125,
+    pages = {306-312},
+   eprint = {1202.3665},
+      doi = {10.1086/670067}
+}
+"""
+
+try:
+    __EMCEE_SETUP__
+except NameError:
+    __EMCEE_SETUP__ = False
+
+if not __EMCEE_SETUP__:
+    from .ensemble import EnsembleSampler
+
+    from . import moves
+    from . import autocorr
+    from . import backends
+
+    __all__ = ["EnsembleSampler", "moves", "autocorr", "backends"]

--- a/refnx/_lib/emcee/autocorr.py
+++ b/refnx/_lib/emcee/autocorr.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+import logging
+
+import numpy as np
+
+__all__ = ["function_1d", "integrated_time", "AutocorrError"]
+
+
+def next_pow_two(n):
+    """Returns the next power of two greater than or equal to `n`"""
+    i = 1
+    while i < n:
+        i = i << 1
+    return i
+
+
+def function_1d(x):
+    """Estimate the normalized autocorrelation function of a 1-D series
+
+    Args:
+        x: The series as a 1-D numpy array.
+
+    Returns:
+        array: The autocorrelation function of the time series.
+
+    """
+    x = np.atleast_1d(x)
+    if len(x.shape) != 1:
+        raise ValueError("invalid dimensions for 1D autocorrelation function")
+    n = next_pow_two(len(x))
+
+    # Compute the FFT and then (from that) the auto-correlation function
+    f = np.fft.fft(x - np.mean(x), n=2 * n)
+    acf = np.fft.ifft(f * np.conjugate(f))[:len(x)].real
+    acf /= acf[0]
+    return acf
+
+
+def auto_window(taus, c):
+    m = np.arange(len(taus)) < c * taus
+    if np.any(m):
+        return np.argmin(m)
+    return len(taus) - 1
+
+
+def integrated_time(x, c=5, tol=50, quiet=False):
+    """Estimate the integrated autocorrelation time of a time series.
+
+    This estimate uses the iterative procedure described on page 16 of
+    `Sokal's notes <http://www.stat.unc.edu/faculty/cji/Sokal.pdf>`_ to
+    determine a reasonable window size.
+
+    Args:
+        x: The time series. If multidimensional, set the time axis using the
+            ``axis`` keyword argument and the function will be computed for
+            every other axis.
+        c (Optional[float]): The step size for the window search. (default:
+            ``5``)
+        tol (Optional[float]): The minimum number of autocorrelation times
+            needed to trust the estimate. (default: ``50``)
+        quiet (Optional[bool]): This argument controls the behavior when the
+            chain is too short. If ``True``, give a warning instead of raising
+            an :class:`AutocorrError`. (default: ``False``)
+
+    Returns:
+        float or array: An estimate of the integrated autocorrelation time of
+            the time series ``x`` computed along the axis ``axis``.
+        Optional[int]: The final window size that was used. Only returned if
+            ``full_output`` is ``True``.
+
+    Raises
+        AutocorrError: If the autocorrelation time can't be reliably estimated
+            from the chain and ``quiet`` is ``False``. This normally means
+            that the chain is too short.
+
+    """
+    x = np.atleast_1d(x)
+    if len(x.shape) == 1:
+        x = x[:, np.newaxis, np.newaxis]
+    if len(x.shape) == 2:
+        x = x[:, :, np.newaxis]
+    if len(x.shape) != 3:
+        raise ValueError("invalid dimensions")
+
+    n_t, n_w, n_d = x.shape
+    tau_est = np.empty(n_d)
+    windows = np.empty(n_d, dtype=int)
+
+    # Loop over parameters
+    for d in range(n_d):
+        f = np.zeros(n_t)
+        for k in range(n_w):
+            f += function_1d(x[:, k, d])
+        f /= n_w
+        taus = 2.0 * np.cumsum(f) - 1.0
+        windows[d] = auto_window(taus, c)
+        tau_est[d] = taus[windows[d]]
+
+    # Check convergence
+    flag = tol * tau_est > n_t
+
+    # Warn or raise in the case of non-convergence
+    if np.any(flag):
+        msg = (
+            "The chain is shorter than {0} times the integrated "
+            "autocorrelation time for {1} parameter(s). Use this estimate "
+            "with caution and run a longer chain!\n"
+        ).format(tol, np.sum(flag))
+        msg += "N/{0} = {1:.0f};\ntau: {2}".format(tol, n_t / tol, tau_est)
+        if not quiet:
+            raise AutocorrError(tau_est, msg)
+        logging.warning(msg)
+
+    return tau_est
+
+
+class AutocorrError(Exception):
+    """Raised if the chain is too short to estimate an autocorrelation time.
+
+    The current estimate of the autocorrelation time can be accessed via the
+    ``tau`` attribute of this exception.
+
+    """
+    def __init__(self, tau, *args, **kwargs):
+        self.tau = tau
+        super(AutocorrError, self).__init__(*args, **kwargs)

--- a/refnx/_lib/emcee/backends/__init__.py
+++ b/refnx/_lib/emcee/backends/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+__all__ = [
+    "Backend",
+    "HDFBackend", "TempHDFBackend",
+    "get_test_backends",
+]
+
+from .backend import Backend
+from .hdf import HDFBackend, TempHDFBackend
+
+
+def get_test_backends():
+    backends = [Backend]
+
+    try:
+        import h5py  # NOQA
+    except ImportError:
+        pass
+    else:
+        backends.append(TempHDFBackend)
+
+    return backends

--- a/refnx/_lib/emcee/backends/backend.py
+++ b/refnx/_lib/emcee/backends/backend.py
@@ -1,0 +1,247 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+__all__ = ["Backend"]
+
+import numpy as np
+
+from .. import autocorr
+
+
+class Backend(object):
+    """A simple default backend that stores the chain in memory"""
+
+    def __init__(self):
+        self.initialized = False
+
+    def reset(self, nwalkers, ndim):
+        """Clear the state of the chain and empty the backend
+
+        Args:
+            nwakers (int): The size of the ensemble
+            ndim (int): The number of dimensions
+
+        """
+        self.nwalkers = int(nwalkers)
+        self.ndim = int(ndim)
+        self.iteration = 0
+        self.accepted = np.zeros(self.nwalkers, dtype=int)
+        self.chain = np.empty((0, self.nwalkers, self.ndim))
+        self.log_prob = np.empty((0, self.nwalkers))
+        self.blobs = None
+        self.random_state = None
+        self.initialized = True
+
+    def has_blobs(self):
+        """Returns ``True`` if the model includes blobs"""
+        return self.blobs is not None
+
+    def get_value(self, name, flat=False, thin=1, discard=0):
+        if self.iteration <= 0:
+            raise AttributeError("you must run the sampler with "
+                                 "'store == True' before accessing the "
+                                 "results")
+
+        if name == "blobs" and not self.has_blobs():
+            return None
+
+        v = getattr(self, name)[discard + thin - 1:self.iteration:thin]
+        if flat:
+            s = list(v.shape[1:])
+            s[0] = np.prod(v.shape[:2])
+            return v.reshape(s)
+        return v
+
+    def get_chain(self, **kwargs):
+        """Get the stored chain of MCMC samples
+
+        Args:
+            flat (Optional[bool]): Flatten the chain across the ensemble.
+                (default: ``False``)
+            thin (Optional[int]): Take only every ``thin`` steps from the
+                chain. (default: ``1``)
+            discard (Optional[int]): Discard the first ``discard`` steps in
+                the chain as burn-in. (default: ``0``)
+
+        Returns:
+            array[..., nwalkers, ndim]: The MCMC samples.
+
+        """
+        return self.get_value("chain", **kwargs)
+
+    def get_blobs(self, **kwargs):
+        """Get the chain of blobs for each sample in the chain
+
+        Args:
+            flat (Optional[bool]): Flatten the chain across the ensemble.
+                (default: ``False``)
+            thin (Optional[int]): Take only every ``thin`` steps from the
+                chain. (default: ``1``)
+            discard (Optional[int]): Discard the first ``discard`` steps in
+                the chain as burn-in. (default: ``0``)
+
+        Returns:
+            array[..., nwalkers]: The chain of blobs.
+
+        """
+        return self.get_value("blobs", **kwargs)
+
+    def get_log_prob(self, **kwargs):
+        """Get the chain of log probabilities evaluated at the MCMC samples
+
+        Args:
+            flat (Optional[bool]): Flatten the chain across the ensemble.
+                (default: ``False``)
+            thin (Optional[int]): Take only every ``thin`` steps from the
+                chain. (default: ``1``)
+            discard (Optional[int]): Discard the first ``discard`` steps in
+                the chain as burn-in. (default: ``0``)
+
+        Returns:
+            array[..., nwalkers]: The chain of log probabilities.
+
+        """
+        return self.get_value("log_prob", **kwargs)
+
+    def get_last_sample(self):
+        """Access the most recent sample in the chain
+
+        This method returns a tuple with
+
+        * ``coords`` - A list of the current positions of the walkers in the
+          parameter space. The shape of this object will be
+          ``(nwalkers, dim)``.
+
+        * ``log_prob`` - The list of log posterior probabilities for the
+          walkers at positions given by ``coords`` . The shape of this object
+          is ``(nwalkers,)``.
+
+        * ``rstate`` - The current state of the random number generator.
+
+        * ``blobs`` - (optional) The metadata "blobs" associated with the
+          current position. The value is only returned if blobs have been
+          saved during sampling.
+
+        """
+        if (not self.initialized) or self.iteration <= 0:
+            raise AttributeError("you must run the sampler with "
+                                 "'store == True' before accessing the "
+                                 "results")
+        it = self.iteration
+        last = [
+            self.get_chain(discard=it - 1)[0],
+            self.get_log_prob(discard=it - 1)[0],
+            self.random_state,
+        ]
+        blob = self.get_blobs(discard=it - 1)
+        if blob is not None:
+            last.append(blob[0])
+        return tuple(last)
+
+    def get_autocorr_time(self, discard=0, thin=1, **kwargs):
+        """Compute an estimate of the autocorrelation time for each parameter
+
+        Args:
+            thin (Optional[int]): Use only every ``thin`` steps from the
+                chain. The returned estimate is multiplied by ``thin`` so the
+                estimated time is in units of steps, not thinned steps.
+                (default: ``1``)
+            discard (Optional[int]): Discard the first ``discard`` steps in
+                the chain as burn-in. (default: ``0``)
+
+        Other arguments are passed directly to
+        :func:`emcee.autocorr.integrated_time`.
+
+        Returns:
+            array[ndim]: The integrated autocorrelation time estimate for the
+                chain for each parameter.
+
+        """
+        x = self.get_chain(discard=discard, thin=thin)
+        return thin * autocorr.integrated_time(x, **kwargs)
+
+    @property
+    def shape(self):
+        """The dimensions of the ensemble ``(nwalkers, ndim)``"""
+        return self.nwalkers, self.ndim
+
+    def _check_blobs(self, blobs):
+        has_blobs = self.has_blobs()
+        if has_blobs and blobs is None:
+            raise ValueError("inconsistent use of blobs")
+        if self.iteration > 0 and blobs is not None and not has_blobs:
+            raise ValueError("inconsistent use of blobs")
+
+    def grow(self, ngrow, blobs):
+        """Expand the storage space by some number of samples
+
+        Args:
+            ngrow (int): The number of steps to grow the chain.
+            blobs: The current list of blobs. This is used to compute the
+                dtype for the blobs array.
+
+        """
+        self._check_blobs(blobs)
+        i = ngrow - (len(self.chain) - self.iteration)
+        a = np.empty((i, self.nwalkers, self.ndim))
+        self.chain = np.concatenate((self.chain, a), axis=0)
+        a = np.empty((i, self.nwalkers))
+        self.log_prob = np.concatenate((self.log_prob, a), axis=0)
+        if blobs is not None:
+            dt = np.dtype((blobs[0].dtype, blobs[0].shape))
+            a = np.empty((i, self.nwalkers), dtype=dt)
+            if self.blobs is None:
+                self.blobs = a
+            else:
+                self.blobs = np.concatenate((self.blobs, a), axis=0)
+
+    def _check(self, coords, log_prob, blobs, accepted):
+        self._check_blobs(blobs)
+        nwalkers, ndim = self.shape
+        has_blobs = self.has_blobs()
+        if coords.shape != (nwalkers, ndim):
+            raise ValueError("invalid coordinate dimensions; expected {0}"
+                             .format((nwalkers, ndim)))
+        if log_prob.shape != (nwalkers, ):
+            raise ValueError("invalid log probability size; expected {0}"
+                             .format(nwalkers))
+        if blobs is not None and not has_blobs:
+            raise ValueError("unexpected blobs")
+        if blobs is None and has_blobs:
+            raise ValueError("expected blobs, but none were given")
+        if blobs is not None and len(blobs) != nwalkers:
+            raise ValueError("invalid blobs size; expected {0}"
+                             .format(nwalkers))
+        if accepted.shape != (nwalkers, ):
+            raise ValueError("invalid acceptance size; expected {0}"
+                             .format(nwalkers))
+
+    def save_step(self, coords, log_prob, blobs, accepted, random_state):
+        """Save a step to the backend
+
+        Args:
+            coords (ndarray): The coordinates of the walkers in the ensemble.
+            log_prob (ndarray): The log probability for each walker.
+            blobs (ndarray or None): The blobs for each walker or ``None`` if
+                there are no blobs.
+            accepted (ndarray): An array of boolean flags indicating whether
+                or not the proposal for each walker was accepted.
+            random_state: The current state of the random number generator.
+
+        """
+        self._check(coords, log_prob, blobs, accepted)
+
+        self.chain[self.iteration, :, :] = coords
+        self.log_prob[self.iteration, :] = log_prob
+        if blobs is not None:
+            self.blobs[self.iteration, :] = blobs
+        self.accepted += accepted
+        self.random_state = random_state
+        self.iteration += 1
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        pass

--- a/refnx/_lib/emcee/backends/hdf.py
+++ b/refnx/_lib/emcee/backends/hdf.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+__all__ = ["HDFBackend", "TempHDFBackend"]
+
+import os
+from tempfile import NamedTemporaryFile
+
+import numpy as np
+
+try:
+    import h5py
+except ImportError:
+    h5py = None
+
+from .backend import Backend
+from .. import __version__
+
+
+class HDFBackend(Backend):
+    """A backend that stores the chain in an HDF5 file using h5py
+
+    .. note:: You must install `h5py <http://www.h5py.org/>`_ to use this
+        backend.
+
+    Args:
+        filename (str): The name of the HDF5 file where the chain will be
+            saved.
+        name (str; optional): The name of the group where the chain will
+            be saved.
+        read_only (bool; optional): If ``True``, the backend will throw a
+            ``RuntimeError`` if the file is opened with write access.
+
+    """
+    def __init__(self, filename, name="mcmc", read_only=False):
+        if h5py is None:
+            raise ImportError("you must install 'h5py' to use the HDFBackend")
+        self.filename = filename
+        self.name = name
+        self.read_only = read_only
+
+    @property
+    def initialized(self):
+        if not os.path.exists(self.filename):
+            return False
+        try:
+            with self.open() as f:
+                return self.name in f
+        except (OSError, IOError):
+            return False
+
+    def open(self, mode="r"):
+        if self.read_only and mode != "r":
+            raise RuntimeError("The backend has been loaded in read-only "
+                               "mode. Set `read_only = False` to make "
+                               "changes.")
+        return h5py.File(self.filename, mode)
+
+    def reset(self, nwalkers, ndim):
+        """Clear the state of the chain and empty the backend
+
+        Args:
+            nwakers (int): The size of the ensemble
+            ndim (int): The number of dimensions
+
+        """
+        with self.open("w") as f:
+            g = f.create_group(self.name)
+            g.attrs["version"] = __version__
+            g.attrs["nwalkers"] = nwalkers
+            g.attrs["ndim"] = ndim
+            g.attrs["has_blobs"] = False
+            g.attrs["iteration"] = 0
+            g.create_dataset("accepted", data=np.zeros(nwalkers, dtype=int))
+            g.create_dataset("chain",
+                             (0, nwalkers, ndim),
+                             maxshape=(None, nwalkers, ndim),
+                             dtype=np.float64)
+            g.create_dataset("log_prob",
+                             (0, nwalkers),
+                             maxshape=(None, nwalkers),
+                             dtype=np.float64)
+
+    def has_blobs(self):
+        with self.open() as f:
+            return f[self.name].attrs["has_blobs"]
+
+    def get_value(self, name, flat=False, thin=1, discard=0):
+        if not self.initialized:
+            raise AttributeError("You must run the sampler with "
+                                 "'store == True' before accessing the "
+                                 "results")
+        with self.open() as f:
+            g = f[self.name]
+            iteration = g.attrs["iteration"]
+            if iteration <= 0:
+                raise AttributeError("You must run the sampler with "
+                                     "'store == True' before accessing the "
+                                     "results")
+
+            if name == "blobs" and not g.attrs["has_blobs"]:
+                return None
+
+            v = g[name][discard + thin - 1:self.iteration:thin]
+            if flat:
+                s = list(v.shape[1:])
+                s[0] = np.prod(v.shape[:2])
+                return v.reshape(s)
+            return v
+
+    @property
+    def shape(self):
+        with self.open() as f:
+            g = f[self.name]
+            return g.attrs["nwalkers"], g.attrs["ndim"]
+
+    @property
+    def iteration(self):
+        with self.open() as f:
+            return f[self.name].attrs["iteration"]
+
+    @property
+    def accepted(self):
+        with self.open() as f:
+            return f[self.name]["accepted"][...]
+
+    @property
+    def random_state(self):
+        with self.open() as f:
+            elements = [
+                v
+                for k, v in sorted(f[self.name].attrs.items())
+                if k.startswith("random_state_")
+            ]
+        return elements if len(elements) else None
+
+    def grow(self, ngrow, blobs):
+        """Expand the storage space by some number of samples
+
+        Args:
+            ngrow (int): The number of steps to grow the chain.
+            blobs: The current list of blobs. This is used to compute the
+                dtype for the blobs array.
+
+        """
+        self._check_blobs(blobs)
+
+        with self.open("a") as f:
+            g = f[self.name]
+            ntot = g.attrs["iteration"] + ngrow
+            g["chain"].resize(ntot, axis=0)
+            g["log_prob"].resize(ntot, axis=0)
+            if blobs is not None:
+                has_blobs = g.attrs["has_blobs"]
+                if not has_blobs:
+                    nwalkers = g.attrs["nwalkers"]
+                    dt = np.dtype((blobs[0].dtype, blobs[0].shape))
+                    g.create_dataset("blobs", (ntot, nwalkers),
+                                     maxshape=(None, nwalkers),
+                                     dtype=dt)
+                else:
+                    g["blobs"].resize(ntot, axis=0)
+                g.attrs["has_blobs"] = True
+
+    def save_step(self, coords, log_prob, blobs, accepted, random_state):
+        """Save a step to the file
+
+        Args:
+            coords (ndarray): The coordinates of the walkers in the ensemble.
+            log_prob (ndarray): The log probability for each walker.
+            blobs (ndarray or None): The blobs for each walker or ``None`` if
+                there are no blobs.
+            accepted (ndarray): An array of boolean flags indicating whether
+                or not the proposal for each walker was accepted.
+            random_state: The current state of the random number generator.
+
+        """
+        self._check(coords, log_prob, blobs, accepted)
+
+        with self.open("a") as f:
+            g = f[self.name]
+            iteration = g.attrs["iteration"]
+
+            g["chain"][iteration, :, :] = coords
+            g["log_prob"][iteration, :] = log_prob
+            if blobs is not None:
+                g["blobs"][iteration, :] = blobs
+            g["accepted"][:] += accepted
+
+            for i, v in enumerate(random_state):
+                g.attrs["random_state_{0}".format(i)] = v
+
+            g.attrs["iteration"] = iteration + 1
+
+
+class TempHDFBackend(object):
+
+    def __enter__(self):
+        f = NamedTemporaryFile("w", delete=False)
+        f.close()
+        self.filename = f.name
+        return HDFBackend(f.name, "test")
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        os.remove(self.filename)

--- a/refnx/_lib/emcee/ensemble.py
+++ b/refnx/_lib/emcee/ensemble.py
@@ -1,0 +1,496 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+__all__ = ["EnsembleSampler"]
+
+from collections import Iterable
+
+import numpy as np
+
+from .backends import Backend
+from .moves import StretchMove
+from .pbar import get_progress_bar
+from .utils import deprecated, deprecation_warning
+
+
+class EnsembleSampler(object):
+    """An ensemble MCMC sampler
+
+    Args:
+        nwalkers (int): The number of walkers in the ensemble.
+        ndim (int): Number of dimensions in the parameter space.
+        log_prob_fn (callable): A function that takes a vector in the
+            parameter space as input and returns the natural logarithm of the
+            posterior probability (up to an additive constant) for that
+            position.
+        moves (Optional): This can be a single move object, a list of moves,
+            or a "weighted" list of the form ``[(emcee.moves.StretchMove(),
+            0.1), ...]``. When running, the sampler will randomly select a
+            move from this list (optionally with weights) for each proposal.
+            (default: :class:`StretchMove`)
+        args (Optional): A list of extra positional arguments for
+            ``log_prob_fn``. ``log_prob_fn`` will be called with the sequence
+            ``log_pprob_fn(p, *args, **kwargs)``.
+        kwargs (Optional): A dict of extra keyword arguments for
+            ``log_prob_fn``. ``log_prob_fn`` will be called with the sequence
+            ``log_pprob_fn(p, *args, **kwargs)``.
+        pool (Optional): An object with a ``map`` method that follows the same
+            calling sequence as the built-in ``map`` function. This is
+            generally used to compute the log-probabilities for the ensemble
+            in parallel.
+        backend (Optional): Either a :class:`backends.Backend` or a subclass
+            (like :class:`backends.HDFBackend`) that is used to store and
+            serialize the state of the chain. By default, the chain is stored
+            as a set of numpy arrays in memory, but new backends can be
+            written to support other mediums.
+        vectorize (Optional[bool]): If ``True``, ``log_prob_fn`` is expected
+            to accept a list of position vectors instead of just one. Note
+            that ``pool`` will be ignored if this is ``True``.
+            (default: ``False``)
+
+    """
+    def __init__(self, nwalkers, ndim, log_prob_fn,
+                 pool=None, moves=None,
+                 args=None, kwargs=None,
+                 backend=None,
+                 vectorize=False,
+                 blobs_dtype=None,
+                 # Deprecated...
+                 a=None, postargs=None, threads=None, live_dangerously=None,
+                 runtime_sortingfn=None):
+        # Warn about deprecated arguments
+        if a is not None:
+            deprecation_warning(
+                "The 'a' argument is deprecated, use 'moves' instead")
+        if threads is not None:
+            deprecation_warning(
+                "The 'threads' argument is deprecated")
+        if runtime_sortingfn is not None:
+            deprecation_warning(
+                "The 'runtime_sortingfn' argument is deprecated")
+        if live_dangerously is not None:
+            deprecation_warning(
+                "The 'live_dangerously' argument is deprecated")
+
+        # Parse the move schedule
+        if moves is None:
+            self._moves = [StretchMove()]
+            self._weights = [1.0]
+        elif isinstance(moves, Iterable):
+            try:
+                self._moves, self._weights = zip(*moves)
+            except TypeError:
+                self._moves = moves
+                self._weights = np.ones(len(moves))
+        else:
+            self._moves = [moves]
+            self._weights = [1.0]
+        self._weights = np.atleast_1d(self._weights).astype(float)
+        self._weights /= np.sum(self._weights)
+
+        self.pool = pool
+        self.vectorize = vectorize
+        self.blobs_dtype = blobs_dtype
+
+        self.ndim = ndim
+        self.nwalkers = nwalkers
+        self.backend = Backend() if backend is None else backend
+
+        # Deal with re-used backends
+        if not self.backend.initialized:
+            self.reset()
+            state = np.random.get_state()
+        else:
+            # Check the backend shape
+            if self.backend.shape != (self.nwalkers, self.ndim):
+                raise ValueError(
+                    ("the shape of the backend ({0}) is incompatible with the "
+                     "shape of the sampler ({1})")
+                    .format(self.backend.shape,
+                            (self.nwalkers, self.ndim)))
+
+            # Get the last random state
+            state = self.backend.random_state
+            if state is None:
+                state = np.random.get_state()
+
+            # Grab the last step so that we can restart
+            it = self.backend.iteration
+            if it > 0:
+                self._last_run_mcmc_result = self.get_last_sample()
+
+        # This is a random number generator that we can easily set the state
+        # of without affecting the numpy-wide generator
+        self._random = np.random.mtrand.RandomState()
+        self._random.set_state(state)
+
+        # Do a little bit of _magic_ to make the likelihood call with
+        # ``args`` and ``kwargs`` pickleable.
+        self.log_prob_fn = _FunctionWrapper(log_prob_fn, args, kwargs)
+
+    @property
+    def random_state(self):
+        """
+        The state of the internal random number generator. In practice, it's
+        the result of calling ``get_state()`` on a
+        ``numpy.random.mtrand.RandomState`` object. You can try to set this
+        property but be warned that if you do this and it fails, it will do
+        so silently.
+
+        """
+        return self._random.get_state()
+
+    @random_state.setter  # NOQA
+    def random_state(self, state):
+        """
+        Try to set the state of the random number generator but fail silently
+        if it doesn't work. Don't say I didn't warn you...
+
+        """
+        try:
+            self._random.set_state(state)
+        except Exception:
+            pass
+
+    @property
+    def iteration(self):
+        return self.backend.iteration
+
+    def reset(self):
+        """
+        Reset the bookkeeping parameters
+
+        """
+        self._last_run_mcmc_result = None
+        self.backend.reset(self.nwalkers, self.ndim)
+
+    def __getstate__(self):
+        # In order to be generally picklable, we need to discard the pool
+        # object before trying.
+        d = self.__dict__
+        d["pool"] = None
+        return d
+
+    def sample(self, p0, log_prob0=None, rstate0=None, blobs0=None,
+               iterations=1, thin_by=1, thin=None, store=True, progress=False):
+        """Advance the chain as a generator
+
+        Args:
+            p0 (ndarray[nwalkers, ndim]): The initial positions of the walkers
+                in the parameter space.
+            log_prob0 (Optional[ndarray[nwalkers]]): The log posterior
+                probabilities for the walkers at ``p0``. If ``log_prob0 is
+                None``, the initial values are calculated.
+            rstate0 (Optional): The state of the random number generator.
+                See the :attr:`EnsembleSampler.random_state` property for
+                details.
+            iterations (Optional[int]): The number of steps to generate.
+            thin_by (Optional[int]): If you only want to store and yield every
+                ``thin_by`` samples in the chain, set ``thin_by`` to an
+                integer greater than 1. When this is set, ``iterations *
+                thin_by`` proposals will be made.
+            store (Optional[bool]): By default, the sampler stores (in memory)
+                the positions and log-probabilities of the samples in the
+                chain. If you are using another method to store the samples to
+                a file or if you don't need to analyze the samples after the
+                fact (for burn-in for example) set ``store`` to ``False``.
+
+        Every ``thin_by`` steps, this generator yields:
+
+        * ``coords`` - A list of the current positions of the walkers in the
+          parameter space. The shape of this object will be
+          ``(nwalkers, dim)``.
+
+        * ``log_prob`` - The list of log posterior probabilities for the
+          walkers at positions given by ``pos`` . The shape of this object
+          is ``(nwalkers,)``.
+
+        * ``rstate`` - The current state of the random number generator.
+
+        * ``blobs`` - (optional) The metadata "blobs" associated with the
+          current position. The value is only returned if ``log_prob_fn``
+          returns blobs too.
+
+        """
+        # Try to set the initial value of the random number generator. This
+        # fails silently if it doesn't work but that's what we want because
+        # we'll just interpret any garbage as letting the generator stay in
+        # it's current state.
+        self.random_state = rstate0
+        p = np.array(p0)
+        if np.shape(p) != (self.nwalkers, self.ndim):
+            raise ValueError("incompatible input dimensions")
+
+        # If the initial log-probabilities were not provided, calculate them
+        # now.
+        log_prob = log_prob0
+        blobs = blobs0
+        if log_prob is None:
+            log_prob, blobs = self.compute_log_prob(p)
+        if np.shape(log_prob) != (self.nwalkers, ):
+            raise ValueError("incompatible input dimensions")
+
+        # Check to make sure that the probability function didn't return
+        # ``np.nan``.
+        if np.any(np.isnan(log_prob)):
+            raise ValueError("The initial log_prob was NaN")
+
+        # Deal with deprecated thin argument
+        if thin is not None:
+            deprecation_warning("The 'thin' argument is deprecated. "
+                                "Use 'thin_by' instead.")
+
+            # Check that the thin keyword is reasonable.
+            thin = int(thin)
+            if thin <= 0:
+                raise ValueError("Invalid thinning argument")
+
+            yield_step = 1
+            checkpoint_step = thin
+            iterations = int(iterations)
+            if store:
+                nsaves = iterations // checkpoint_step
+                self.backend.grow(nsaves, blobs)
+
+        else:
+            # Check that the thin keyword is reasonable.
+            thin_by = int(thin_by)
+            if thin_by <= 0:
+                raise ValueError("Invalid thinning argument")
+
+            yield_step = thin_by
+            checkpoint_step = thin_by
+            iterations = int(iterations)
+            if store:
+                self.backend.grow(iterations, blobs)
+
+        # Inject the progress bar
+        total = iterations * yield_step
+        with get_progress_bar(progress, total) as pbar:
+            i = 0
+            for _ in range(iterations):
+                for _ in range(yield_step):
+                    # Choose a random move
+                    move = self._random.choice(self._moves, p=self._weights)
+
+                    # Propose
+                    p, log_prob, blobs, accepted = move.propose(
+                        p, log_prob, blobs, self.compute_log_prob,
+                        self._random)
+
+                    # Save the new step
+                    if store and (i + 1) % checkpoint_step == 0:
+                        self.backend.save_step(p, log_prob, blobs, accepted,
+                                               self.random_state)
+
+                    pbar.update(1)
+                    i += 1
+
+                # Yield the result as an iterator so that the user can do all
+                # sorts of fun stuff with the results so far.
+                if blobs is not None:
+                    # This is a bit of a hack to keep things backwards
+                    # compatible.
+                    yield p, log_prob, self.random_state, blobs
+                else:
+                    yield p, log_prob, self.random_state
+
+    def run_mcmc(self, pos0, nsteps, rstate0=None, log_prob0=None,
+                 blobs0=None, **kwargs):
+        """
+        Iterate :func:`sample` for ``nsteps`` iterations and return the result
+
+        Args:
+            pos0: The initial position vector. Can also be ``None`` to resume
+                from where :func:``run_mcmc`` left off the last time it
+                executed.
+            nsteps: The number of steps to run.
+            log_prob0 (Optional[ndarray[nwalkers]]): The log posterior
+                probabilities for the walkers at ``p0``. If ``log_prob0 is
+                None``, the initial values are calculated.
+            rstate0 (Optional): The state of the random number generator.
+                See the :attr:`EnsembleSampler.random_state` property for
+                details.
+
+        Other parameters are directly passed to :func:`sample`.
+
+        This method returns the most recent result from :func:`sample`. The
+        particular values vary from sampler to sampler, but the result is
+        generally a tuple ``(pos, log_prob, rstate)`` or
+        ``(pos, log_prob, rstate, blobs)`` where ``pos`` is the most recent
+        position vector (or ensemble thereof), ``log_prob`` is the most recent
+        log posterior probability (or ensemble thereof), ``rstate`` is the
+        state of the random number generator, and the optional ``blobs`` are
+        user-provided large data blobs.
+
+        """
+        if pos0 is None:
+            if self._last_run_mcmc_result is None:
+                raise ValueError("Cannot have pos0=None if run_mcmc has never "
+                                 "been called.")
+            pos0, log_prob0, rstate0 = self._last_run_mcmc_result[:3]
+            if len(self._last_run_mcmc_result) > 3:
+                blobs0 = self._last_run_mcmc_result[3]
+
+        results = None
+        for results in self.sample(pos0, log_prob0, rstate0=rstate0,
+                                   blobs0=blobs0, iterations=nsteps, **kwargs):
+            pass
+
+        # Store so that the ``pos0=None`` case will work
+        self._last_run_mcmc_result = results
+
+        return results
+
+    def compute_log_prob(self, coords):
+        """Calculate the vector of log-probability for the walkers
+
+        Args:
+            coords: (ndarray[..., ndim]) The position vector in parameter
+                space where the probability should be calculated.
+
+        This method returns:
+
+        * log_prob: A vector of log-probabilities with one entry for each
+          walker in this sub-ensemble.
+        * blob: The list of meta data returned by the ``log_post_fn`` at
+          this position or ``None`` if nothing was returned.
+
+        """
+        p = coords
+
+        # Check that the parameters are in physical ranges.
+        if np.any(np.isinf(p)):
+            raise ValueError("At least one parameter value was infinite")
+        if np.any(np.isnan(p)):
+            raise ValueError("At least one parameter value was NaN")
+
+        # Run the log-probability calculations (optionally in parallel).
+        if self.vectorize:
+            results = self.log_prob_fn(p)
+        else:
+            # If the `pool` property of the sampler has been set (i.e. we want
+            # to use `multiprocessing`), use the `pool`'s map method.
+            # Otherwise, just use the built-in `map` function.
+            if self.pool is not None:
+                map_func = self.pool.map
+            else:
+                map_func = map
+            results = list(map_func(self.log_prob_fn,
+                                    (p[i] for i in range(len(p)))))
+
+        try:
+            log_prob = np.array([float(l[0]) for l in results])
+            blob = [l[1:] for l in results]
+        except (IndexError, TypeError):
+            log_prob = np.array([float(l) for l in results])
+            blob = None
+        else:
+            # Get the blobs dtype
+            if self.blobs_dtype is not None:
+                dt = self.blobs_dtype
+            else:
+                dt = np.atleast_1d(blob[0]).dtype
+            blob = np.array(blob, dtype=dt)
+
+            # Deal with single blobs in a better way
+            if len(blob.shape) > 1 and blob.shape[1] == 1:
+                m = [slice(None) for i in range(len(blob.shape))]
+                m[1] = 0
+                blob = blob[m]
+
+        # Check for log_prob returning NaN.
+        if np.any(np.isnan(log_prob)):
+            raise ValueError("Probability function returned NaN")
+
+        return log_prob, blob
+
+    @property
+    def acceptance_fraction(self):
+        """The fraction of proposed steps that were accepted"""
+        return self.backend.accepted / float(self.backend.iteration)
+
+    @property
+    @deprecated("get_chain()")
+    def chain(self):  # pragma: no cover
+        chain = self.get_chain()
+        return np.swapaxes(chain, 0, 1)
+
+    @property
+    @deprecated("get_chain(flat=True)")
+    def flatchain(self):  # pragma: no cover
+        return self.get_chain(flat=True)
+
+    @property
+    @deprecated("get_log_prob()")
+    def lnprobability(self):  # pragma: no cover
+        return self.get_log_prob()
+
+    @property
+    @deprecated("get_log_prob(flat=True)")
+    def flatlnprobability(self):  # pragma: no cover
+        return self.get_log_prob(flat=True)
+
+    @property
+    @deprecated("get_blobs()")
+    def blobs(self):  # pragma: no cover
+        return self.get_blobs()
+
+    @property
+    @deprecated("get_blobs(flat=True)")
+    def flatblobs(self):  # pragma: no cover
+        return self.get_blobs(flat=True)
+
+    @property
+    @deprecated("get_autocorr_time")
+    def acor(self):  # pragma: no cover
+        return self.get_autocorr_time()
+
+    def get_chain(self, **kwargs):
+        return self.get_value("chain", **kwargs)
+    get_chain.__doc__ = Backend.get_chain.__doc__
+
+    def get_blobs(self, **kwargs):
+        return self.get_value("blobs", **kwargs)
+    get_blobs.__doc__ = Backend.get_blobs.__doc__
+
+    def get_log_prob(self, **kwargs):
+        return self.get_value("log_prob", **kwargs)
+    get_log_prob.__doc__ = Backend.get_log_prob.__doc__
+
+    def get_last_sample(self, **kwargs):
+        return self.backend.get_last_sample()
+    get_last_sample.__doc__ = Backend.get_last_sample.__doc__
+
+    def get_value(self, name, **kwargs):
+        return self.backend.get_value(name, **kwargs)
+
+    def get_autocorr_time(self, **kwargs):
+        return self.backend.get_autocorr_time(**kwargs)
+    get_autocorr_time.__doc__ = Backend.get_autocorr_time.__doc__
+
+
+class _FunctionWrapper(object):
+    """
+    This is a hack to make the likelihood function pickleable when ``args``
+    or ``kwargs`` are also included.
+
+    """
+    def __init__(self, f, args, kwargs):
+        self.f = f
+        self.args = [] if args is None else args
+        self.kwargs = {} if kwargs is None else kwargs
+
+    def __call__(self, x):
+        try:
+            return self.f(x, *self.args, **self.kwargs)
+        except Exception:  # pragma: no cover
+            import traceback
+            print("emcee: Exception while calling your likelihood function:")
+            print("  params:", x)
+            print("  args:", self.args)
+            print("  kwargs:", self.kwargs)
+            print("  exception:")
+            traceback.print_exc()
+            raise

--- a/refnx/_lib/emcee/interruptible_pool.py
+++ b/refnx/_lib/emcee/interruptible_pool.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+__all__ = ["InterruptiblePool"]
+
+# The standard library now has an interruptible pool
+from multiprocessing.pool import Pool as InterruptiblePool

--- a/refnx/_lib/emcee/moves/__init__.py
+++ b/refnx/_lib/emcee/moves/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+from .move import Move
+
+from .mh import MHMove
+from .gaussian import GaussianMove
+
+from .red_blue import RedBlueMove
+from .stretch import StretchMove
+from .walk import WalkMove
+from .kde import KDEMove
+
+from .de import DEMove
+from .de_snooker import DESnookerMove
+
+__all__ = [
+    "Move",
+    "MHMove", "GaussianMove",
+    "RedBlueMove", "StretchMove", "WalkMove", "KDEMove",
+    "DEMove", "DESnookerMove",
+]

--- a/refnx/_lib/emcee/moves/de.py
+++ b/refnx/_lib/emcee/moves/de.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+import numpy as np
+from .red_blue import RedBlueMove
+
+__all__ = ["DEMove"]
+
+
+class DEMove(RedBlueMove):
+    """A proposal using differential evolution.
+
+    This `Differential evolution proposal
+    <http://www.stat.columbia.edu/~gelman/stuff_for_blog/cajo.pdf>`_ is
+    implemented following `Nelson et al. (2013)
+    <http://arxiv.org/abs/1311.5229>`_.
+
+    Args:
+        sigma (float): The standard deviation of the Gaussian used to stretch
+            the proposal vector.
+        gamma0 (Optional[float]): The mean stretch factor for the proposal
+            vector. By default, it is :math:`2.38 / \sqrt{2\,\mathrm{ndim}}`
+            as recommended by the two references.
+
+    """
+    def __init__(self, sigma, gamma0=None, **kwargs):
+        self.sigma = sigma
+        self.gamma0 = gamma0
+        kwargs["nsplits"] = 3
+        super(DEMove, self).__init__(**kwargs)
+
+    def setup(self, coords):
+        self.g0 = self.gamma0
+        if self.g0 is None:
+            # Pure MAGIC:
+            ndim = coords.shape[1]
+            self.g0 = 2.38 / np.sqrt(2 * ndim)
+
+    def get_proposal(self, s, c, random):
+        Ns = len(s)
+        Nc = list(map(len, c))
+        ndim = s.shape[1]
+        q = np.empty((Ns, ndim), dtype=np.float64)
+        f = random.randn(Ns)
+        for i in range(Ns):
+            w = np.array([c[j][random.randint(Nc[j])] for j in range(2)])
+            random.shuffle(w)
+            g = np.diff(w, axis=0) * (1 + self.g0 * f[i])
+            q[i] = s[i] + g
+        return q, np.zeros(Ns, dtype=np.float64)

--- a/refnx/_lib/emcee/moves/de_snooker.py
+++ b/refnx/_lib/emcee/moves/de_snooker.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+import numpy as np
+from .red_blue import RedBlueMove
+
+__all__ = ["DESnookerMove"]
+
+
+class DESnookerMove(RedBlueMove):
+    """A snooker proposal using differential evolution.
+
+    Based on `Ter Braak & Vrugt (2008)
+    <http://link.springer.com/article/10.1007/s11222-008-9104-9>`_.
+
+    Credit goes to GitHub user `mdanthony17 <https://github.com/mdanthony17>`_
+    for proposing this as an addition to the original emcee package.
+
+    Args:
+        gammas (Optional[float]): The mean stretch factor for the proposal
+            vector. By default, it is :math:`1.7` as recommended by the
+            reference.
+
+    """
+    def __init__(self, gammas=1.7, **kwargs):
+        self.gammas = gammas
+        kwargs["nsplits"] = 4
+        super(DESnookerMove, self).__init__(**kwargs)
+
+    def get_proposal(self, s, c, random):
+        Ns = len(s)
+        Nc = list(map(len, c))
+        ndim = s.shape[1]
+        q = np.empty((Ns, ndim), dtype=np.float64)
+        metropolis = np.empty(Ns, dtype=np.float64)
+        for i in range(Ns):
+            w = np.array([c[j][random.randint(Nc[j])] for j in range(3)])
+            random.shuffle(w)
+            z, z1, z2 = w
+            delta = s[i] - z
+            norm = np.linalg.norm(delta)
+            u = delta / np.sqrt(norm)
+            q[i] = s[i] + u * self.gammas * (np.dot(u, z1) - np.dot(u, z2))
+            metropolis[i] = np.log(np.linalg.norm(q[i] - z)) - np.log(norm)
+        return q, 0.5 * (ndim - 1.0) * metropolis

--- a/refnx/_lib/emcee/moves/gaussian.py
+++ b/refnx/_lib/emcee/moves/gaussian.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+import numpy as np
+
+from .mh import MHMove
+
+__all__ = ["GaussianMove"]
+
+
+class GaussianMove(MHMove):
+    """A Metropolis step with a Gaussian proposal function.
+
+    Args:
+        cov: The covariance of the proposal function. This can be a scalar,
+            vector, or matrix and the proposal will be assumed isotropic,
+            axis-aligned, or general respectively.
+        mode (Optional): Select the method used for updating parameters. This
+            can be one of ``"vector"``, ``"random"``, or ``"sequential"``. The
+            ``"vector"`` mode updates all dimensions simultaneously,
+            ``"random"`` randomly selects a dimension and only updates that
+            one, and ``"sequential"`` loops over dimensions and updates each
+            one in turn.
+        factor (Optional[float]): If provided the proposal will be made with a
+            standard deviation uniformly selected from the range
+            ``exp(U(-log(factor), log(factor))) * cov``. This is invalid for
+            the ``"vector"`` mode.
+
+    Raises:
+        ValueError: If the proposal dimensions are invalid or if any of any of
+            the other arguments are inconsistent.
+
+    """
+    def __init__(self, cov, mode="vector", factor=None):
+        # Parse the proposal type.
+        try:
+            float(cov)
+
+        except TypeError:
+            cov = np.atleast_1d(cov)
+            if len(cov.shape) == 1:
+                # A diagonal proposal was given.
+                ndim = len(cov)
+                proposal = _diagonal_proposal(np.sqrt(cov), factor, mode)
+
+            elif len(cov.shape) == 2 and cov.shape[0] == cov.shape[1]:
+                # The full, square covariance matrix was given.
+                ndim = cov.shape[0]
+                proposal = _proposal(cov, factor, mode)
+
+            else:
+                raise ValueError("Invalid proposal scale dimensions")
+
+        else:
+            # This was a scalar proposal.
+            ndim = None
+            proposal = _isotropic_proposal(np.sqrt(cov), factor, mode)
+
+        super(GaussianMove, self).__init__(proposal, ndim=ndim)
+
+
+class _isotropic_proposal(object):
+
+    allowed_modes = ["vector", "random", "sequential"]
+
+    def __init__(self, scale, factor, mode):
+        self.index = 0
+        self.scale = scale
+        if factor is None:
+            self._log_factor = None
+        else:
+            if factor < 1.0:
+                raise ValueError("'factor' must be >= 1.0")
+            self._log_factor = np.log(factor)
+
+        if mode not in self.allowed_modes:
+            raise ValueError(("'{0}' is not a recognized mode. "
+                              "Please select from: {1}")
+                             .format(mode, self.allowed_modes))
+        self.mode = mode
+
+    def get_factor(self, rng):
+        if self._log_factor is None:
+            return 1.0
+        return np.exp(rng.uniform(-self._log_factor, self._log_factor))
+
+    def get_updated_vector(self, rng, x0):
+        return x0 + self.get_factor(rng) * self.scale * rng.randn(*(x0.shape))
+
+    def __call__(self, x0, rng):
+        nw, nd = x0.shape
+        xnew = self.get_updated_vector(rng, x0)
+        if self.mode == "random":
+            m = (range(nw), rng.randint(x0.shape[-1], size=nw))
+        elif self.mode == "sequential":
+            m = (range(nw), self.index % nd + np.zeros(nw, dtype=int))
+            self.index = (self.index + 1) % nd
+        else:
+            return xnew, np.zeros(nw)
+        x = np.array(x0)
+        x[m] = xnew[m]
+        return x, np.zeros(nw)
+
+
+class _diagonal_proposal(_isotropic_proposal):
+
+    def get_updated_vector(self, rng, x0):
+        return x0 + self.get_factor(rng) * self.scale * rng.randn(*(x0.shape))
+
+
+class _proposal(_isotropic_proposal):
+
+    allowed_modes = ["vector"]
+
+    def get_updated_vector(self, rng, x0):
+        return x0 + self.get_factor(rng) * rng.multivariate_normal(
+            np.zeros(len(self.scale)), self.scale)

--- a/refnx/_lib/emcee/moves/kde.py
+++ b/refnx/_lib/emcee/moves/kde.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+import numpy as np
+
+try:
+    from scipy.stats import gaussian_kde
+except ImportError:
+    gaussian_kde = None
+
+from .red_blue import RedBlueMove
+
+__all__ = ["KDEMove"]
+
+
+class KDEMove(RedBlueMove):
+    """A proposal using a KDE of the complementary ensemble
+
+    This is a simplified version of the method used in `kombine
+    <https://github.com/bfarr/kombine>`_. If you use this proposal, you should
+    use *a lot* of walkers in your ensemble.
+
+    Args:
+        bw_method: The bandwidth estimation method. See `the scipy docs
+            <http://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.gaussian_kde.html>`_
+            for allowed values.
+
+    """
+    def __init__(self, bw_method=None, **kwargs):
+        if gaussian_kde is None:
+            raise ImportError("you need scipy.stats.gaussian_kde to use the "
+                              "KDEMove")
+        self.bw_method = bw_method
+        super(KDEMove, self).__init__(**kwargs)
+
+    def get_proposal(self, s, c, random):
+        c = np.concatenate(c, axis=0)
+        kde = gaussian_kde(c.T, bw_method=self.bw_method)
+        q = kde.resample(len(s))
+        factor = kde.logpdf(s.T) - kde.logpdf(q)
+        return q.T, factor

--- a/refnx/_lib/emcee/moves/mh.py
+++ b/refnx/_lib/emcee/moves/mh.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+import numpy as np
+
+from .move import Move
+
+__all__ = ["MHMove"]
+
+
+class MHMove(Move):
+    """A general Metropolis-Hastings proposal
+
+    Concrete implementations can be made by providing a ``proposal_function``
+    argument that implements the proposal as described below.
+    For standard Gaussian Metropolis moves, :class:`moves.GaussianMove` can be
+    used.
+
+    Args:
+        proposal_function: The proposal function. It should take 2 arguments: a
+            numpy-compatible random number generator and a ``(K, ndim)`` list
+            of coordinate vectors. This function should return the proposed
+            position and the log-ratio of the proposal probabilities
+            (:math:`\ln q(x;\,x^\prime) - \ln q(x^\prime;\,x)` where
+            :math:`x^\prime` is the proposed coordinate).
+        ndim (Optional[int]): If this proposal is only valid for a specific
+            dimension of parameter space, set that here.
+
+    """
+    def __init__(self, proposal_function, ndim=None):
+        self.ndim = ndim
+        self.get_proposal = proposal_function
+
+    def propose(self, coords, log_probs, blobs, log_prob_fn, random):
+        """Use the move to generate a proposal and compute the acceptance
+
+        Args:
+            coords: The initial coordinates of the walkers.
+            log_probs: The initial log probabilities of the walkers.
+            log_prob_fn: A function that computes the log probabilities for a
+                subset of walkers.
+            random: A numpy-compatible random number state.
+
+        """
+        # Check to make sure that the dimensions match.
+        nwalkers, ndim = coords.shape
+        if self.ndim is not None and self.ndim != ndim:
+            raise ValueError("Dimension mismatch in proposal")
+
+        # Get the move-specific proposal.
+        q, factors = self.get_proposal(coords, random)
+
+        # Compute the lnprobs of the proposed position.
+        new_log_probs, new_blobs = log_prob_fn(q)
+
+        # Loop over the walkers and update them accordingly.
+        lnpdiff = new_log_probs - log_probs + factors
+        accepted = np.log(random.rand(nwalkers)) < lnpdiff
+
+        # Update the parameters
+        coords, log_probs, blobs = self.update(
+            coords, log_probs, blobs,
+            q, new_log_probs, new_blobs,
+            accepted)
+
+        return coords, log_probs, blobs, accepted

--- a/refnx/_lib/emcee/moves/move.py
+++ b/refnx/_lib/emcee/moves/move.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+import numpy as np
+
+__all__ = ["Move"]
+
+
+class Move(object):
+
+    def update(self,
+               coords, log_probs, blobs,
+               new_coords, new_log_probs, new_blobs,
+               accepted, subset=None):
+        """Update a given subset of the ensemble with an accepted proposal
+
+        Args:
+            coords: The original ensemble coordinates.
+            log_probs: The original log probabilities of the walkers.
+            blobs: The original blobs.
+            new_coords: The proposed coordinates.
+            new_log_probs: The proposed log probabilities.
+            new_blobs: The proposed blobs.
+            accepted: A vector of booleans indicating which walkers were
+                accepted.
+            subset (Optional): A boolean mask indicating which walkers were
+                included in the subset. This can be used, for example, when
+                updating only the primary ensemble in a :class:`RedBlueMove`.
+
+        """
+        if subset is None:
+            subset = np.ones(len(coords), dtype=bool)
+        m1 = subset & accepted
+        m2 = accepted[subset]
+        coords[m1] = new_coords[m2]
+        log_probs[m1] = new_log_probs[m2]
+
+        if new_blobs is not None:
+            if blobs is None:
+                raise ValueError(
+                    "If you start sampling with a given lnprob, "
+                    "you also need to provide the current list of "
+                    "blobs at that position.")
+            blobs[m1] = new_blobs[m2]
+
+        return coords, log_probs, blobs

--- a/refnx/_lib/emcee/moves/red_blue.py
+++ b/refnx/_lib/emcee/moves/red_blue.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+import numpy as np
+
+from .move import Move
+
+__all__ = ["RedBlueMove"]
+
+
+class RedBlueMove(Move):
+    """
+    An abstract red-blue ensemble move with parallelization as described in
+    `Foreman-Mackey et al. (2013) <http://arxiv.org/abs/1202.3665>`_.
+
+    Args:
+        nsplits (Optional[int]): The number of sub-ensembles to use. Each
+            sub-ensemble is updated in parallel using the other sets as the
+            complementary ensemble. The default value is ``2`` and you
+            probably won't need to change that.
+
+        randomize_split (Optional[bool]): Randomly shuffle walkers between
+            sub-ensembles. The same number of walkers will be assigned to
+            each sub-ensemble on each iteration. By default, this is ``False``.
+
+        live_dangerously (Optional[bool]): By default, an update will fail with
+            a ``RuntimeError`` if the number of walkers is smaller than twice
+            the dimension of the problem because the walkers would then be
+            stuck on a low dimensional subspace. This can be avoided by
+            switching between the stretch move and, for example, a
+            Metropolis-Hastings step. If you want to do this and suppress the
+            error, set ``live_dangerously = True``. Thanks goes (once again)
+            to @dstndstn for this wonderful terminology.
+
+    """
+    def __init__(self,
+                 nsplits=2,
+                 randomize_split=True,
+                 live_dangerously=False):
+        self.nsplits = int(nsplits)
+        self.live_dangerously = live_dangerously
+        self.randomize_split = randomize_split
+
+    def setup(self, coords):
+        pass
+
+    def get_proposal(self, sample, complement, random):
+        raise NotImplementedError("The proposal must be implemented by "
+                                  "subclasses")
+
+    def propose(self, coords, log_probs, blobs, log_prob_fn, random):
+        """Use the move to generate a proposal and compute the acceptance
+
+        Args:
+            coords: The initial coordinates of the walkers.
+            log_probs: The initial log probabilities of the walkers.
+            log_prob_fn: A function that computes the log probabilities for a
+                subset of walkers.
+            random: A numpy-compatible random number state.
+
+        """
+        # Check that the dimensions are compatible.
+        nwalkers, ndim = coords.shape
+        if nwalkers < 2 * ndim and not self.live_dangerously:
+            raise RuntimeError("It is unadvisable to use a red-blue move "
+                               "with fewer walkers than twice the number of "
+                               "dimensions.")
+
+        # Run any move-specific setup.
+        self.setup(coords)
+
+        # Split the ensemble in half and iterate over these two halves.
+        accepted = np.zeros(nwalkers, dtype=bool)
+        all_inds = np.arange(nwalkers)
+        inds = all_inds % self.nsplits
+        if self.randomize_split:
+            random.shuffle(inds)
+        for split in range(self.nsplits):
+            S1 = inds == split
+
+            # Get the two halves of the ensemble.
+            sets = [coords[inds == j] for j in range(self.nsplits)]
+            s = sets[split]
+            c = sets[:split] + sets[split + 1:]
+
+            # Get the move-specific proposal.
+            q, factors = self.get_proposal(s, c, random)
+
+            # Compute the lnprobs of the proposed position.
+            new_log_probs, new_blobs = log_prob_fn(q)
+
+            # Loop over the walkers and update them accordingly.
+            for i, (j, f, nlp) in enumerate(zip(
+                    all_inds[S1], factors, new_log_probs)):
+                lnpdiff = f + nlp - log_probs[j]
+                if lnpdiff > np.log(random.rand()):
+                    accepted[j] = True
+
+            coords, log_probs, blobs = self.update(
+                coords, log_probs, blobs,
+                q, new_log_probs, new_blobs,
+                accepted, S1)
+
+        return coords, log_probs, blobs, accepted

--- a/refnx/_lib/emcee/moves/stretch.py
+++ b/refnx/_lib/emcee/moves/stretch.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+import numpy as np
+
+from .red_blue import RedBlueMove
+
+__all__ = ["StretchMove"]
+
+
+class StretchMove(RedBlueMove):
+    """
+    A `Goodman & Weare (2010)
+    <http://msp.berkeley.edu/camcos/2010/5-1/p04.xhtml>`_ "stretch move" with
+    parallelization as described in `Foreman-Mackey et al. (2013)
+    <http://arxiv.org/abs/1202.3665>`_.
+
+    :param a: (optional)
+        The stretch scale parameter. (default: ``2.0``)
+
+    """
+    def __init__(self, a=2.0, **kwargs):
+        self.a = a
+        super(StretchMove, self).__init__(**kwargs)
+
+    def get_proposal(self, s, c, random):
+        c = np.concatenate(c, axis=0)
+        Ns, Nc = len(s), len(c)
+        ndim = s.shape[1]
+        zz = ((self.a - 1.) * random.rand(Ns) + 1) ** 2. / self.a
+        factors = (ndim - 1.) * np.log(zz)
+        rint = random.randint(Nc, size=(Ns,))
+        return c[rint] - (c[rint] - s) * zz[:, None], factors

--- a/refnx/_lib/emcee/moves/walk.py
+++ b/refnx/_lib/emcee/moves/walk.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+import numpy as np
+from .red_blue import RedBlueMove
+
+__all__ = ["WalkMove"]
+
+
+class WalkMove(RedBlueMove):
+    """
+    A `Goodman & Weare (2010)
+    <http://msp.berkeley.edu/camcos/2010/5-1/p04.xhtml>`_ "walk move" with
+    parallelization as described in `Foreman-Mackey et al. (2013)
+    <http://arxiv.org/abs/1202.3665>`_.
+
+    :param s: (optional)
+        The number of helper walkers to use. By default it will use all the
+        walkers in the complement.
+
+    """
+    def __init__(self, s=None, **kwargs):
+        self.s = s
+        super(WalkMove, self).__init__(**kwargs)
+
+    def get_proposal(self, s, c, random):
+        c = np.concatenate(c, axis=0)
+        Ns, Nc = len(s), len(c)
+        ndim = s.shape[1]
+        q = np.empty((Ns, ndim), dtype=np.float64)
+        s0 = Nc if self.s is None else self.s
+        for i in range(Ns):
+            inds = random.choice(Nc, s0, replace=False)
+            cov = np.atleast_2d(np.cov(c[inds], rowvar=0))
+            q[i] = random.multivariate_normal(s[i], cov)
+        return q, np.zeros(Ns, dtype=np.float64)

--- a/refnx/_lib/emcee/mpi_pool.py
+++ b/refnx/_lib/emcee/mpi_pool.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, absolute_import
+
+try:
+    from schwimmbad import MPIPool
+except ImportError:
+
+    class MPIPool(object):
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "The MPIPool from emcee has been forked to "
+                "https://github.com/adrn/schwimmbad, "
+                "please install that package to continue using the MPIPool"
+            )
+
+__all__ = ["MPIPool"]

--- a/refnx/_lib/emcee/pbar.py
+++ b/refnx/_lib/emcee/pbar.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+__all__ = ["get_progress_bar"]
+
+import logging
+
+try:
+    from tqdm import tqdm
+except ImportError:
+    tqdm = None
+
+
+class _NoOpPBar(object):
+    """This class implements the progress bar interface but does nothing"""
+    def __init__(self):
+        pass
+
+    def __enter__(self, *args, **kwargs):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        pass
+
+    def update(self, count):
+        pass
+
+
+def get_progress_bar(display, total):
+    """Get a progress bar interface with given properties
+
+    If the tqdm library is not installed, this will always return a "progress
+    bar" that does nothing.
+
+    Args:
+        display (bool): Should the bar actually show the progress?
+        total (int): The total size of the progress bar.
+
+    """
+    if not display:
+        return _NoOpPBar()
+    if tqdm is None:
+        logging.warn("You must install the tqdm library to use progress "
+                     "indicators with emcee")
+        return _NoOpPBar()
+    return tqdm(total=total)

--- a/refnx/_lib/emcee/ptsampler.py
+++ b/refnx/_lib/emcee/ptsampler.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, absolute_import
+
+try:
+    from ptemcee import Sampler as PTSampler
+except ImportError:
+
+    class PTSampler(object):
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "The PTSampler from emcee has been forked to "
+                "https://github.com/willvousden/ptemcee, "
+                "please install that package to continue using the PTSampler"
+            )
+
+__all__ = ["PTSampler"]

--- a/refnx/_lib/emcee/utils.py
+++ b/refnx/_lib/emcee/utils.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+__all__ = ["sample_ball", "deprecated", "deprecation_warning"]
+
+import warnings
+from functools import wraps
+
+import numpy as np
+
+
+def deprecation_warning(msg):
+    warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+
+
+def deprecated(alternate):
+    def wrapper(func, alternate=alternate):
+        msg = "'{0}' is deprecated.".format(func.__name__)
+        if alternate is not None:
+            msg += " Use '{0}' instead.".format(alternate)
+
+        @wraps(func)
+        def f(*args, **kwargs):
+            deprecation_warning(msg)
+            return func(*args, **kwargs)
+        return f
+
+    return wrapper
+
+
+@deprecated(None)
+def sample_ball(p0, std, size=1):
+    """
+    Produce a ball of walkers around an initial parameter value.
+
+    :param p0: The initial parameter value.
+    :param std: The axis-aligned standard deviation.
+    :param size: The number of samples to produce.
+
+    """
+    assert(len(p0) == len(std))
+    return np.vstack([p0 + std * np.random.normal(size=len(p0))
+                      for i in range(size)])
+
+
+@deprecated(None)
+def sample_ellipsoid(p0, covmat, size=1):
+    """
+    Produce an ellipsoid of walkers around an initial parameter value,
+    according to a covariance matrix.
+
+    :param p0: The initial parameter value.
+    :param covmat:
+        The covariance matrix.  Must be symmetric-positive definite or
+        it will raise the exception numpy.linalg.LinAlgError
+    :param size: The number of samples to produce.
+
+    """
+    return np.random.multivariate_normal(np.atleast_1d(p0),
+                                         np.atleast_2d(covmat),
+                                         size=size)

--- a/refnx/_lib/util.py
+++ b/refnx/_lib/util.py
@@ -14,7 +14,7 @@ except ImportError:
     from inspect import getargspec as _getargspecf
 
 
-from emcee.interruptible_pool import InterruptiblePool
+from refnx._lib.emcee.interruptible_pool import InterruptiblePool
 
 
 def preserve_cwd(function):

--- a/refnx/analysis/curvefitter.py
+++ b/refnx/analysis/curvefitter.py
@@ -31,6 +31,8 @@ except ImportError:
     except ImportError:
         warnings.warn("PTSampler (parallel tempering) is not available,"
                       " please install the ptemcee package", ImportWarning)
+        PTSampler = None
+
 try:
     import tqdm as tqdm
 except ImportError:
@@ -168,12 +170,10 @@ class CurveFitter(object):
         -----
         See the documentation at http://dan.iel.fm/emcee/current/api/ for
         further details on what keywords are permitted. The `pool` and
-        `threads` keywords are ignored here. Specification of parallel
-        threading is done with the `pool` argument in the `sample` method.
-        Parallel tempering has been forked into a separate python package,
-        :package:`ptemcee`, and may not be present in more recent versions
-        of :package:`emcee`. To use parallel tempering you may need to
-        install the :package:`ptemcee` package.
+        keyword is ignored here. Specification of parallel threading is done
+        with the `pool` argument in the `sample` method.
+        To use parallel tempering you will need to install the
+        :package:`ptemcee` package.
         """
         self.objective = objective
         self._varying_parameters = objective.varying_parameters()
@@ -332,20 +332,17 @@ class CurveFitter(object):
         Parameters
         ----------
         chain : array
-            Array of size `(ntemps, nwalkers, steps, ndim)` or
-            `(nwalkers, steps, ndim)`, containing a chain from a previous
+            Array of size `(steps, ntemps, nwalkers, ndim)` or
+            `(steps, nwalkers, ndim)`, containing a chain from a previous
             sampling run.
         """
         # we should be left with (nwalkers, ndim) or (ntemp, nwalkers, ndim)
-        existing_chain_shape = list(self.sampler.chain.shape)
-        existing_chain_shape.pop(-2)
-
-        chain_shape = list(chain.shape)
-        chain_shape.pop(-2)
+        existing_chain_shape = self.chain.shape[1:]
+        chain_shape = chain.shape[1:]
 
         # if the shapes are the same, then we can initialise
         if existing_chain_shape == chain_shape:
-            self.initialise(pos=chain[..., -1, :])
+            self.initialise(pos=chain[-1])
         else:
             raise ValueError("You tried to initialise with a chain, but it was"
                              " the wrong shape")
@@ -358,9 +355,33 @@ class CurveFitter(object):
         Returns
         -------
         chain : array
-            The MCMC chain belonging to CurveFitter.sampler
+            The MCMC chain with shape `(steps, nwalkers, ndim)` or
+            `(steps, ntemps, nwalkers, ndim)`.
+
+        Notes
+        -----
+        The chain returned here has swapped axes compared to the
+        `PTSampler.chain` and `EnsembleSampler.chain` attributes
         """
-        return self.sampler.chain
+        if isinstance(self.sampler, PTSampler):
+            return np.transpose(self.sampler.chain, axes=(2, 0, 1, 3))
+
+        return self.sampler.get_chain()
+
+    @property
+    def lnprob(self):
+        """
+        Log-probability for each of the entries in self.chain
+
+        Returns
+        -------
+        lnprob : array
+
+        """
+        if isinstance(self.sampler, PTSampler):
+            return np.transpose(self.sampler.logprobability, axes=(2, 0, 1))
+
+        return self.sampler.get_log_prob()
 
     def acf(self, nburn=0, nthin=1):
         """
@@ -371,22 +392,21 @@ class CurveFitter(object):
         acfs : np.ndarray
             The autocorrelation function, acfs.shape=(lags, nvary)
         """
-        chain = np.copy(self.sampler.chain)
+        lchain = self.chain
         if self._ntemps != -1:
-            chain = chain[0]
+            lchain = lchain[:, 0]
 
-        chain = chain[:, nburn::nthin, :]
-
+        lchain = lchain[nburn::nthin]
+        # iterations, walkers, vary
         # (walkers, iterations, vary) -> (vary, walkers, iterations)
-        chain = np.transpose(chain, (2, 0, 1))
-        shape = list(chain.shape)
-        shape.pop(-1)
+        lchain = np.swapaxes(lchain, 0, 2)
+        shape = lchain.shape[:-1]
 
-        acfs = np.zeros_like(chain)
+        acfs = np.zeros_like(lchain)
 
         # iterate over each parameter/walker
         for index in np.ndindex(*shape):
-            s = _function_1d(chain[index])
+            s = _function_1d(lchain[index])
             acfs[index] = s
 
         # now average over walkers
@@ -401,10 +421,10 @@ class CurveFitter(object):
         Parameters
         ----------
         steps : int
-            Iterate the sampler by a number of steps
+            Collect `steps` samples into the chain. The sampler will run a
+            total of `steps * nthin` moves.
         nthin : int, optional
-            only store every `nthin` samples from the chain. `nthin` should be
-            a divisor of `steps`.
+            Each chain sample is separated by `nthin` iterations.
         random_state : int or `np.random.RandomState`, optional
             If `random_state` is an int, a new `np.random.RandomState` instance
             is used, seeded with `random_state`.
@@ -414,7 +434,7 @@ class CurveFitter(object):
         f : file-like or str
             File to incrementally save chain progress to. Each row in the file
             is a flattened array of size `(nwalkers, ndim)` or
-            `(ntemps, nwalkers, ndim)`. There should be `steps` rows in the
+            `(ntemps, nwalkers, ndim)`. There are `steps` rows in the
             file.
         callback : callable
             callback function to be called at each iteration step
@@ -430,80 +450,38 @@ class CurveFitter(object):
         Notes
         -----
         Please see :class:`emcee.EnsembleSampler` for its detailed behaviour.
-        For example, the chain is contained in `CurveFitter.sampler.chain` and
-        has shape `(nwalkers, iterations, ndim)`. If you wish to 'burn' a
-        number of samples to start with then use the following pattern:
 
-        >>> # we'll burn the first 500
+        >>> # we'll burn the first 500 steps
         >>> fitter.sample(500)
         >>> # after you've run those, then discard them by resetting the
         >>> # sampler.
         >>> fitter.sampler.reset()
-        >>> # Now do a production run only saving 1 in every 50 samples
-        >>> fitter.sample(2000, nthin=50)
+        >>> # Now collect 40 steps, each step separated by 50 sampler
+        >>> # generations.
+        >>> fitter.sample(40, nthin=50)
 
         One can also burn and thin in `Curvefitter.process_chain`.
         """
-        if steps % nthin:
-            steps = steps - steps % nthin
-            print("Warning - setting steps to be multiple of nthin")
-
         if self._lastpos is None:
             self.initialise()
 
-        start_time = time.time()
+        self.__pt_iterations = 0
+        if isinstance(self.sampler, PTSampler):
+            steps *= nthin
 
-        # record how many iterations have already been run on sampler
-        try:
-            if hasattr(self.sampler, 'iterations'):
-                init_iterations = self.sampler.iterations
-            elif hasattr(self.sampler, 'time'):
-                init_iterations = self.sampler.time
-            else:
-                init_iterations = np.size(self.chain, -2)
-        except (AttributeError, IndexError):
-            init_iterations = 0
-
-        def step_progress():
-            try:
-                # using old emcee
-                if hasattr(self.sampler, 'iterations'):
-                    return self.sampler.iterations
-                elif hasattr(self.sampler, 'time'):
-                    return self.sampler.time
-
-                iter = np.size(self.sampler.chain, -2) - init_iterations
-            except (AttributeError, IndexError):
-                iter = 0
-            return iter * nthin
-
-        # for saving progress to file, and printing progress to stdout.
+        # for saving progress to file
         def _callback_wrapper(pos, lnprob, h=None):
-            steps_completed = step_progress()
-
-            if verbose:
-                width = 50
-                step_rate = (time.time() - start_time) / steps_completed
-                time_remaining = divmod(step_rate * (steps - steps_completed),
-                                        60)
-                mins, secs = int(time_remaining[0]), int(time_remaining[1])
-                emins, esecs = divmod((time.time() - start_time), 60)
-                n = int((width + 1) * float(steps_completed) / steps)
-                template = ("\r[{0}{1}] "
-                            "{2}/{3}, "
-                            "Time: {4} m:{5} s / {6} m:{7} s")
-                sys.stdout.write(template.format('#' * n,
-                                                 ' ' * (width - n),
-                                                 steps_completed,
-                                                 steps,
-                                                 int(emins),
-                                                 int(esecs),
-                                                 mins,
-                                                 secs))
             if callback is not None:
                 callback(pos, lnprob)
-            if (h is not None) and (steps_completed % nthin == 0):
-                # (nwalkers, dim) or (ntemps, nwalkers, dim)
+
+            if h is not None:
+                # if you're parallel tempering, then you only
+                # want to save every nthin
+                if isinstance(self.sampler, PTSampler):
+                    self.__pt_iterations += 1
+                    if self.__pt_iterations % nthin:
+                        return None
+
                 h.write(' '.join(map(str, pos.ravel())))
                 h.write('\n')
 
@@ -544,14 +522,15 @@ class CurveFitter(object):
             kwargs = {'iterations': steps,
                       'thin': nthin}
 
-            # new emcee has progress keyword. If that's present
-            # then we may be able to use tqdm progress bar.
-            # if not, then we'll just use our own.
-            if ('progress' in getargspec(self.sampler.sample).args and
-                    verbose and
-                    tqdm is not None):
+            # new emcee arguments
+            sampler_args = getargspec(self.sampler.sample).args
+            if 'progress' in sampler_args and verbose and tqdm is not None:
                 kwargs['progress'] = True
                 verbose = False
+
+            if 'thin_by' in sampler_args:
+                kwargs['thin_by'] = nthin
+                kwargs.pop('thin', 0)
 
             for result in self.sampler.sample(self._lastpos,
                                               **kwargs):
@@ -565,7 +544,7 @@ class CurveFitter(object):
             sys.stdout.write("\n")
 
         # sets parameter value and stderr
-        return process_chain(self.objective, self.sampler.chain)
+        return process_chain(self.objective, self.chain)
 
     def fit(self, method='L-BFGS-B', **kws):
         """
@@ -671,8 +650,8 @@ def load_chain(f):
     Returns
     -------
     chain : array
-        The loaded chain - `(nwalkers, nsteps, ndim)` or
-        `(ntemps, nwalkers, nsteps, ndim)`
+        The loaded chain - `(nsteps, nwalkers, ndim)` or
+        `(nsteps, ntemps, nwalkers, ndim)`
     """
     with possibly_open_file(f, 'r') as g:
         # read header
@@ -703,11 +682,8 @@ def load_chain(f):
 
         if ntemps is not None:
             chain = np.reshape(chain, (i, ntemps, nwalkers, ndim))
-            chain = np.swapaxes(chain, 0, 2)
-            chain = np.swapaxes(chain, 0, 1)
         else:
             chain = np.reshape(chain, (i, nwalkers, ndim))
-            chain = np.swapaxes(chain, 0, 1)
 
         return chain
 
@@ -744,31 +720,31 @@ def process_chain(objective, chain, nburn=0, nthin=1, flatchain=False):
 
     Notes
     -----
-    The chain should have the shape `(nwalkers, iterations, nvary)` or
-    `(ntemps, nwalkers, iterations, nvary)` if parallel tempering was
+    The chain should have the shape `(iterations, nwalkers, nvary)` or
+    `(iterations, ntemps, nwalkers, nvary)` if parallel tempering was
     employed.
     The burned and thinned chain is created via:
-    `chain[..., nburn::nthin, :]`.
-    Note, if parallel tempering is employed, then only the first row
+    `chain[nburn::nthin]`.
+    Note, if parallel tempering is employed, then only the lowest temperature
     of the parallel tempering chain is processed and returned as it
     corresponds to the (lowest energy) target distribution.
     If `flatten is True` then the burned/thinned chain is reshaped and
     `arr.reshape(-1, nvary)` is returned.
     This function has the effect of setting the parameter stderr's.
     """
-    chain = chain[..., nburn::nthin, :]
+    chain = chain[nburn::nthin]
     shape = chain.shape
     nvary = shape[-1]
+
+    # nwalkers = shape[1]
     if len(shape) == 4:
-        # nwalkers = shape[1]
-        ntemps = shape[0]
+        ntemps = shape[1]
     elif len(shape) == 3:
-        # nwalkers = shape[0]
         ntemps = -1
 
     if ntemps != -1:
         # PTSampler, we require the target distribution in the first row.
-        chain = chain[0]
+        chain = chain[:, 0]
 
     _flatchain = chain.reshape((-1, nvary))
     if flatchain:

--- a/refnx/analysis/curvefitter.py
+++ b/refnx/analysis/curvefitter.py
@@ -18,25 +18,18 @@ from refnx._lib import (unique as f_unique, possibly_create_pool,
                         possibly_open_file, flatten)
 from refnx._lib.util import getargspec
 
-import emcee as emcee
+from refnx._lib import emcee
+
 # PTSampler has been forked into a separate package. Try both places
 _HAVE_PTSAMPLER = False
-try:
-    from emcee import PTSampler as PTSampler
-    _HAVE_PTSAMPLER = True
-except ImportError:
-    try:
-        from ptemcee.sampler import Sampler as PTSampler
-        _HAVE_PTSAMPLER = True
-    except ImportError:
-        warnings.warn("PTSampler (parallel tempering) is not available,"
-                      " please install the ptemcee package", ImportWarning)
-        PTSampler = None
+PTSampler = type(None)
 
 try:
-    import tqdm as tqdm
+    from ptemcee.sampler import Sampler as PTSampler
+    _HAVE_PTSAMPLER = True
 except ImportError:
-    tqdm = None
+    warnings.warn("PTSampler (parallel tempering) is not available,"
+                  " please install the ptemcee package", ImportWarning)
 
 MCMCResult = namedtuple('MCMCResult', ['name', 'param', 'stderr', 'chain',
                                        'median'])
@@ -126,7 +119,7 @@ class CurveFitter(object):
         If `ntemps == -1`, then an :class:`emcee.EnsembleSampler` is used
         during the `sample` method.
         Otherwise, or if `ntemps is None` then parallel tempering is
-        used with a :class:`emcee.PTSampler` object during the `sample`
+        used with a :class:`ptemcee.sampler.Sampler` object during the `sample`
         method, with `ntemps` specifing the number of temperatures. Can be
         `None`, in which case the `Tmax` keyword argument sets the maximum
         temperature. Parallel Tempering is useful if you expect your
@@ -134,7 +127,7 @@ class CurveFitter(object):
 
     mcmc_kws : dict
         Keywords used to create the :class:`emcee.EnsembleSampler` or
-        :class:`emcee.PTSampler` objects.
+        :class:`ptemcee.sampler.Sampler` objects.
 
     Notes
     -----
@@ -157,14 +150,14 @@ class CurveFitter(object):
             If `ntemps == -1`, then an :class:`emcee.EnsembleSampler` is used
             during the `sample` method.
             Otherwise, or if `ntemps is None` then parallel tempering is
-            used with a :class:`emcee.PTSampler` object during the `sample`
-            method, with `ntemps` specifing the number of temperatures. Can be
-            `None`, in which case the `Tmax` keyword argument sets the maximum
-            temperature. Parallel Tempering is useful if you expect your
-            posterior distribution to be multi-modal.
+            used with a :class:`ptemcee.sampler.Sampler` object during the
+            `sample` method, with `ntemps` specifing the number of
+            temperatures. Can be `None`, in which case the `Tmax` keyword
+            argument sets the maximum temperature. Parallel Tempering is
+            useful if you expect your posterior distribution to be multi-modal.
         mcmc_kws : dict
             Keywords used to create the :class:`emcee.EnsembleSampler` or
-            :class:`emcee.PTSampler` objects.
+            :class:`ptemcee.sampler.PTSampler` objects.
 
         Notes
         -----
@@ -524,7 +517,7 @@ class CurveFitter(object):
 
             # new emcee arguments
             sampler_args = getargspec(self.sampler.sample).args
-            if 'progress' in sampler_args and verbose and tqdm is not None:
+            if 'progress' in sampler_args and verbose:
                 kwargs['progress'] = True
                 verbose = False
 

--- a/refnx/analysis/test/test_curvefitter.py
+++ b/refnx/analysis/test/test_curvefitter.py
@@ -3,7 +3,6 @@ from __future__ import division, print_function
 import os.path
 
 import numpy as np
-import emcee
 import pytest
 from numpy.testing import (assert_, assert_almost_equal, assert_equal,
                            assert_allclose)
@@ -12,6 +11,8 @@ from refnx.analysis import (CurveFitter, Parameter, Parameters, Model,
                             Objective, process_chain, load_chain)
 from refnx.analysis.curvefitter import _HAVE_PTSAMPLER
 from refnx.dataset import Data1D
+from refnx._lib import emcee
+
 from NISTModels import NIST_runner, NIST_Models
 
 

--- a/refnx/analysis/test/test_curvefitter.py
+++ b/refnx/analysis/test/test_curvefitter.py
@@ -104,16 +104,16 @@ class TestCurveFitter(object):
 
         # should be able to multithread
         mcfitter = CurveFitter(self.objective, nwalkers=50)
-        res = mcfitter.sample(steps=66, nthin=2, verbose=False, pool=2)
+        res = mcfitter.sample(steps=33, nthin=2, verbose=False, pool=2)
 
         # check that the autocorrelation function at least runs
         acfs = mcfitter.acf(nburn=10)
         assert_equal(acfs.shape[-1], mcfitter.nvary)
 
-        # check that we're thinning properly
-        assert_equal(mcfitter.sampler.chain.shape, (50, 33, 2))
-        # assert_equal(mcfitter._lastpos, mcfitter.sampler.chain[:, -1, :])
-        assert_equal(res[0].chain.shape, (50, 33))
+        # check chain shape
+        assert_equal(mcfitter.chain.shape, (33, 50, 2))
+        # assert_equal(mcfitter._lastpos, mcfitter.chain[:, -1, :])
+        assert_equal(res[0].chain.shape, (33, 50))
 
     def test_mcmc_pt(self):
         if not _HAVE_PTSAMPLER:
@@ -123,11 +123,11 @@ class TestCurveFitter(object):
         mcfitter = CurveFitter(self.objective, ntemps=10, nwalkers=50)
         assert_equal(mcfitter.sampler.ntemps, 10)
 
-        res = mcfitter.sample(steps=60, nthin=2, verbose=False, pool=0)
-        assert_equal(mcfitter.sampler.chain.shape, (10, 50, 30, 2))
-        assert_equal(res[0].chain.shape, (50, 30))
-        assert_equal(mcfitter.sampler.chain[0, :, :, 0], res[0].chain)
-        assert_equal(mcfitter.sampler.chain[0, :, :, 1], res[1].chain)
+        res = mcfitter.sample(steps=30, nthin=2, verbose=False, pool=0)
+        assert_equal(mcfitter.chain.shape, (30, 10, 50, 2))
+        assert_equal(res[0].chain.shape, (30, 50))
+        assert_equal(mcfitter.chain[:, 0, :, 0], res[0].chain)
+        assert_equal(mcfitter.chain[:, 0, :, 1], res[1].chain)
 
     def test_mcmc_init(self):
         # smoke test for sampler initialisation
@@ -141,14 +141,14 @@ class TestCurveFitter(object):
         assert_equal(mcfitter._lastpos.shape, (100, 2))
         # initialise with last position
         mcfitter.sample(steps=1)
-        chain = mcfitter.sampler.chain
-        mcfitter.initialise(pos=chain[..., -1, :])
+        chain = mcfitter.chain
+        mcfitter.initialise(pos=chain[-1])
         assert_equal(mcfitter._lastpos.shape, (100, 2))
         # initialise with chain
         mcfitter.sample(steps=2)
-        chain = mcfitter.sampler.chain
+        chain = mcfitter.chain
         mcfitter.initialise(pos=chain)
-        assert_equal(mcfitter._lastpos, chain[:, -1, :])
+        assert_equal(mcfitter._lastpos, chain[-1])
 
         if not _HAVE_PTSAMPLER:
             return
@@ -162,14 +162,14 @@ class TestCurveFitter(object):
         assert_equal(mcfitter._lastpos.shape, (20, 100, 2))
         # initialise with last position
         mcfitter.sample(steps=1)
-        chain = mcfitter.sampler.chain
-        mcfitter.initialise(pos=chain[..., -1, :])
+        chain = mcfitter.chain
+        mcfitter.initialise(pos=chain[-1])
         assert_equal(mcfitter._lastpos.shape, (20, 100, 2))
         # initialise with chain
         mcfitter.sample(steps=2)
-        chain = mcfitter.sampler.chain
+        chain = mcfitter.chain
         mcfitter.initialise(pos=np.copy(chain))
-        assert_equal(mcfitter._lastpos, chain[:, :, -1, :])
+        assert_equal(mcfitter._lastpos, chain[-1])
 
     def test_fit_smoke(self):
         # smoke tests to check that fit runs
@@ -289,16 +289,15 @@ class TestFitterGauss(object):
         # test that the checkpoint worked
         check_array = np.loadtxt(checkpoint)
         check_array = check_array.reshape(101, f._nwalkers, f.nvary)
-        assert_allclose(np.swapaxes(check_array, 0, 1),
-                        f.sampler.chain)
+        assert_allclose(check_array, f.chain)
 
         # test loading the checkpoint
         chain = load_chain(checkpoint)
         assert_allclose(chain, f.chain)
 
         f.initialise('jitter')
-        f.sample(steps=9, nthin=4, f=checkpoint, verbose=False)
-        assert_equal(2, f.chain.shape[-2])
+        f.sample(steps=2, nthin=4, f=checkpoint, verbose=False)
+        assert_equal(f.chain.shape[0], 2)
 
         # the following test won't work because of emcee/gh226.
         # chain = load_chain(checkpoint)

--- a/refnx/analysis/test/test_objective.py
+++ b/refnx/analysis/test/test_objective.py
@@ -6,7 +6,6 @@ import pickle
 from multiprocessing.reduction import ForkingPickler
 import os
 
-import emcee
 from scipy.optimize import minimize
 import numpy as np
 from numpy.testing import (assert_almost_equal, assert_equal, assert_,
@@ -16,6 +15,7 @@ from refnx.analysis import (Parameter, Model, Objective, BaseObjective,
                             Transform)
 from refnx.dataset import Data1D, ReflectDataset
 from refnx.util import ErrorProp as EP
+from refnx._lib import emcee
 
 
 def line(x, params, *args, **kwds):

--- a/refnx/reflect/test/test_reflect.py
+++ b/refnx/reflect/test/test_reflect.py
@@ -277,7 +277,7 @@ class TestReflect(object):
         assert_(len(objective.residuals().shape) == 1)
 
         res = fitter.fit('least_squares')
-        res_mcmc = fitter.sample(steps=50, nthin=10, random_state=1,
+        res_mcmc = fitter.sample(steps=5, nthin=10, random_state=1,
                                  verbose=False)
 
         mcmc_val = [mcmc_result.median for mcmc_result in res_mcmc]

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ info = {
         'packages': packages,
         'include_package_data': True,
         'setup_requires': ['numpy'],
-        'install_requires': ['numpy', 'scipy', 'emcee', 'six',
+        'install_requires': ['numpy', 'scipy', 'emcee>=3', 'six',
                              'uncertainties', 'pandas']
         }
 

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ info = {
         'packages': packages,
         'include_package_data': True,
         'setup_requires': ['numpy'],
-        'install_requires': ['numpy', 'scipy', 'emcee', 'six',
+        'install_requires': ['numpy', 'scipy', 'six',
                              'uncertainties', 'pandas']
         }
 

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ info = {
         'packages': packages,
         'include_package_data': True,
         'setup_requires': ['numpy'],
-        'install_requires': ['numpy', 'scipy', 'emcee>=3', 'six',
+        'install_requires': ['numpy', 'scipy', 'emcee', 'six',
                              'uncertainties', 'pandas']
         }
 


### PR DESCRIPTION
This package wishes to use emcee version 3. However, it's not yet released, and the release date is unknown. The master branch is fairly stable and reasonably tested. I therefore think it's possible to have a `refnx._lib.emcee` module, which is a vendored copy of the emcee package.
When emcee version 3 is released that code can be removed, and we can go back to installing the emcee package from PyPI. If modifications are made to the emcee codebase in the meantime, then those modifications can be copied verbatim.
There is no need to fork emcee at this point.