### PR TITLE
BUG: fix covariance calculation

### DIFF
--- a/refnx/analysis/test/test_curvefitter.py
+++ b/refnx/analysis/test/test_curvefitter.py
@@ -260,7 +260,7 @@ class TestFitterGauss(object):
         self.objective.setp(self.p0)
 
         f = CurveFitter(self.objective, nwalkers=100)
-        res = f.fit('least_squares')
+        res = f.fit('least_squares', jac='3-point')
 
         output = res.x
         assert_almost_equal(output, self.best_weighted, 3)
@@ -271,9 +271,9 @@ class TestFitterGauss(object):
         res = (self.data.y - self.model(self.data.x)) / self.data.y_err
         assert_equal(self.objective.residuals(), res)
 
-        # compare objective._covar to the best_weighted_errors
+        # compare objective.covar to the best_weighted_errors
         uncertainties = [param.stderr for param in self.params]
-        assert_allclose(uncertainties, self.best_weighted_errors, rtol=0.01)
+        assert_allclose(uncertainties, self.best_weighted_errors, rtol=0.005)
 
         # we're also going to try the checkpointing here.
         checkpoint = os.path.join(self.tmpdir, 'checkpoint.txt')
@@ -283,9 +283,7 @@ class TestFitterGauss(object):
         f.sample(steps=101, random_state=1, verbose=False, f=checkpoint)
         process_chain(self.objective, f.chain, nburn=50, nthin=10)
         uncertainties = [param.stderr for param in self.params]
-        # assert_allclose(np.array(self.objective.parameters),
-        #                 self.best_weighted, rtol=0.02)
-        assert_allclose(uncertainties, self.best_weighted_errors, rtol=0.2)
+        assert_allclose(uncertainties, self.best_weighted_errors, rtol=0.07)
 
         # test that the checkpoint worked
         check_array = np.loadtxt(checkpoint)

--- a/refnx/analysis/test/test_objective.py
+++ b/refnx/analysis/test/test_objective.py
@@ -7,6 +7,7 @@ from multiprocessing.reduction import ForkingPickler
 import os
 
 import numpy as np
+from numpy.linalg import LinAlgError
 from scipy.optimize import minimize, least_squares
 from scipy.optimize._numdiff import approx_derivative
 from numpy.testing import (assert_almost_equal, assert_equal, assert_,
@@ -376,3 +377,12 @@ class TestObjective(object):
         _pvals = np.array(res.x)
         covar_objective = objective.covar()
         assert_allclose(covar_objective, covar_least_squares)
+
+        # now see what happens with a parameter that has no effect on residuals
+        param = Parameter(1.234, name='dummy')
+        param.vary = True
+        params.append(param)
+
+        from pytest import raises
+        with raises(LinAlgError):
+            objective.covar()

--- a/refnx/reflect/test/test_reflect.py
+++ b/refnx/reflect/test/test_reflect.py
@@ -272,7 +272,6 @@ class TestReflect(object):
                               transform=Transform('logY'))
         fitter = CurveFitter(objective, nwalkers=100)
 
-        print(objective.residuals().shape)
         assert_(len(objective.generative().shape) == 1)
         assert_(len(objective.residuals().shape) == 1)
 


### PR DESCRIPTION
This PR fixes a bug in which the covariance matrix calculated by `objective.covar` was wrong.
The leading diagonal was correct, but the off diagonal elements were rescaled incorrectly.
A test is added to check the covariance matrix against `scipy.optimize.least_squares`.