### PR TITLE
ENH: covar tells you which parameters are singular

### DIFF
--- a/refnx/analysis/objective.py
+++ b/refnx/analysis/objective.py
@@ -615,7 +615,7 @@ class Objective(BaseObjective):
             covar = covar * np.atleast_2d(_pvals) * np.atleast_2d(_pvals).T
 
         pvar = np.diagonal(covar).copy()
-        psingular = np.where(pvar==0)[0]
+        psingular = np.where(pvar == 0)[0]
 
         if len(psingular) > 0:
             var_params = self.varying_parameters()

--- a/refnx/analysis/objective.py
+++ b/refnx/analysis/objective.py
@@ -600,19 +600,30 @@ class Objective(BaseObjective):
         # access to all the datapoints being fitted.
         n_datapoints = np.size(jac, 0)
 
-        # covar = J.T x J.
-        # not sure why this is preferred over Hessian
-        try:
-            covar = np.linalg.inv(np.matmul(jac.T, jac))
-        except LinAlgError:
-            raise LinAlgError("Singular matrix error when inverting Hessian."
-                              " One or more of the Parameters has no effect on"
-                              " Objective.residuals, please consider fixing"
-                              " them.")
+        # covar = J.T x J
+
+        # from scipy.optimize.minpack.py
+        # eliminates singular parameters
+        _, s, VT = np.linalg.svd(jac, full_matrices=False)
+        threshold = np.finfo(float).eps * max(jac.shape) * s[0]
+        s = s[s > threshold]
+        VT = VT[:s.size]
+        covar = np.dot(VT.T / s ** 2, VT)
 
         if used_residuals_scaler:
             # unwind the scaling.
             covar = covar * np.atleast_2d(_pvals) * np.atleast_2d(_pvals).T
+
+        pvar = np.diagonal(covar).copy()
+        psingular = np.where(pvar==0)[0]
+
+        if len(psingular) > 0:
+            var_params = self.varying_parameters()
+            singular_params = [var_params[ps] for ps in psingular]
+
+            raise LinAlgError("The following Parameters have no effect on"
+                              " Objective.residuals, please consider fixing"
+                              " them.\n" + repr(singular_params))
 
         scale = 1.
         # scale by reduced chi2 if experimental uncertainties weren't used.

--- a/refnx/analysis/test/NISTModels.py
+++ b/refnx/analysis/test/NISTModels.py
@@ -173,7 +173,7 @@ NIST_Models = {'Bennett5': (Bennett5, 3, 1),
 
 
 def NIST_runner(dataset, method='least_squares', chi_atol=1e-5,
-                val_rtol=1e-2, err_rtol=0.01):
+                val_rtol=1e-2, err_rtol=5e-3):
     NIST_dataset = ReadNistData(dataset)
     x, y = (NIST_dataset['x'], NIST_dataset['y'])
 

--- a/refnx/analysis/test/test_objective.py
+++ b/refnx/analysis/test/test_objective.py
@@ -361,9 +361,7 @@ class TestObjective(object):
         def residuals_scaler(vals):
             return np.squeeze(objective.residuals(_pvals * vals))
 
-        with np.errstate(invalid='raise'):
-            jac = approx_derivative(residuals_scaler, np.ones_like(_pvals))
-
+        jac = approx_derivative(residuals_scaler, np.ones_like(_pvals))
         hess = np.matmul(jac.T, jac)
         covar = np.linalg.inv(hess)
 


### PR DESCRIPTION
These changes identify which parameters are singular when asking for `objective.covar`.