### PR TITLE
Fix column handling for pandas compatibility

### DIFF
--- a/refnx/reduce/batchreduction.py
+++ b/refnx/reduce/batchreduction.py
@@ -433,7 +433,7 @@ class BatchReducer:
         return ds, fname
 
     def load_runs(self):
-        cols = 'A:I'
+        cols = range(10)
         all_runs = pd.read_excel(
             self.filename,
             usecols=cols,


### PR DESCRIPTION
The syntax for selecting columns varies across pandas releases; this seems to work with all pandas >= 0.20 thus saving a versioned dependency on a difficult-to-build package.