### PR TITLE
BUG: all Parameter instances were sharing same Interval instance

### DIFF
--- a/refnx/analysis/parameter.py
+++ b/refnx/analysis/parameter.py
@@ -356,7 +356,7 @@ def possibly_create_parameter(value, name=''):
 
 
 class Parameter(BaseParameter):
-    def __init__(self, value=0., name=None, bounds=Interval(), vary=False,
+    def __init__(self, value=0., name=None, bounds=None, vary=False,
                  constraint=None):
         """
         Parameters
@@ -376,7 +376,9 @@ class Parameter(BaseParameter):
 
         # set bounds before setting value because the value may not be valid
         # for the bounds
-        self.bounds = bounds
+        self._bounds = Interval()
+        if bounds is not None:
+            self.bounds = bounds
 
         self.value = value
         self._vary = vary

--- a/refnx/analysis/test/test_parameter.py
+++ b/refnx/analysis/test/test_parameter.py
@@ -77,6 +77,12 @@ class TestParameter(object):
         x.setp(bounds=norm(0, 1))
         assert_almost_equal(x.lnprob(1), norm.logpdf(1, 0, 1))
 
+        # all created parameters were mistakenly being given the same
+        # default bounds instance!
+        x = Parameter(4)
+        y = Parameter(5)
+        assert_(id(x.bounds) != id(y.bounds))
+
     def test_range(self):
         x = Parameter(0.)
         x.range(-1, 1.)


### PR DESCRIPTION
All `Parameter` instances were sharing the same `Interval` instance, a reasonably bad bug.