### PR TITLE
MAINT: allow negative background to be added

### DIFF
--- a/refnx/reflect/test/test_reflect.py
+++ b/refnx/reflect/test/test_reflect.py
@@ -195,6 +195,11 @@ class TestReflect(object):
         calc2 = _creflect.abeles(self.qvals, layer0, scale=0.99, bkg=1e-8)
         assert_almost_equal(calc1, calc2)
 
+        # test a negative background
+        calc1 = _reflect.abeles(self.qvals, layer0, scale=0.99, bkg=-5e-7)
+        calc2 = _creflect.abeles(self.qvals, layer0, scale=0.99, bkg=-5e-7)
+        assert_almost_equal(calc1, calc2)
+
     def test_compare_c_py_abeles2(self):
         # test two layer system
         if not TEST_C_REFLECT:

--- a/src/refcalc.cpp
+++ b/src/refcalc.cpp
@@ -165,7 +165,7 @@ void AbelesCalc_ImagAll(int numcoefs,
             num = compnorm(MRtotal[1][0]);
             den = compnorm(MRtotal[0][0]);
             answer = (num / den);
-            answer = (answer * scale) + fabs(bkg);
+            answer = (answer * scale) + bkg;
 
             yP[j] = answer;
         }


### PR DESCRIPTION
The C-plugin was taking the absolute value of the background and adding it to the theoretical reflectivity. The Python equivalent was not taking the absolute value. This PR makes the C-plugin equivalent to the Python version. Those who wish to enforce a background greater than 0 can use a parameter bound.