### PR TITLE
MAINT: change pool organisation

### DIFF
--- a/examples/mpi_parallelisation.py
+++ b/examples/mpi_parallelisation.py
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+"""
+Using refnx in a highly parallelised environment using mpi.
+
+You'll need to install:
+- refnx
+- numpy
+- cython
+- schwimmbad
+- mpi4py
+- ptemcee
+
+Usage
+-----
+mpiexec -n 4 python mpi_parallelisation.py
+"""
+from __future__ import print_function, division
+
+# Start off by importing necessary packages
+import sys
+import os.path
+
+import refnx
+from schwimmbad import MPIPool
+
+from refnx.reflect import SLD, Slab, ReflectModel
+from refnx.dataset import ReflectDataset
+from refnx.analysis import (Objective, CurveFitter, Transform)
+
+
+def setup():
+    # load the data.
+    DATASET_NAME = os.path.join(refnx.__path__[0],
+                                'analysis',
+                                'test',
+                                'c_PLP0011859_q.txt')
+
+    # load the data
+    data = ReflectDataset(DATASET_NAME)
+
+    # the materials we're using
+    si = SLD(2.07, name='Si')
+    sio2 = SLD(3.47, name='SiO2')
+    film = SLD(2, name='film')
+    d2o = SLD(6.36, name='d2o')
+
+    structure = si | sio2(30, 3) | film(250, 3) | d2o(0, 3)
+    structure[1].thick.setp(vary=True, bounds=(15., 50.))
+    structure[1].rough.setp(vary=True, bounds=(1., 6.))
+    structure[2].thick.setp(vary=True, bounds=(200, 300))
+    structure[2].sld.real.setp(vary=True, bounds=(0.1, 3))
+    structure[2].rough.setp(vary=True, bounds=(1, 6))
+
+    model = ReflectModel(structure, bkg=9e-6, scale=1.)
+    model.bkg.setp(vary=True, bounds=(1e-8, 1e-5))
+    model.scale.setp(vary=True, bounds=(0.9, 1.1))
+    model.threads = 1
+    # fit on a logR scale, but use weighting
+    objective = Objective(model, data, transform=Transform('logY'),
+                          use_weights=True)
+
+    return objective
+
+
+if __name__ == "__main__":
+    with MPIPool() as pool:
+        if not pool.is_master():
+            pool.wait()
+            sys.exit(0)
+        # buffering so the program doesn't try to write to the file
+        # constantly
+        with open('steps.chain', 'w', buffering=500000) as f:
+            objective = setup()
+            # Create the fitter and fit
+            fitter = CurveFitter(objective, nwalkers=300, ntemps=15)
+            fitter.initialise('prior')
+            fitter.fit('differential_evolution')
+            # thin by 10 so we have a smaller filesize
+            fitter.sample(100, pool=pool, f=f, verbose=False, nthin=10);
+            f.flush()

--- a/refnx/_lib/__init__.py
+++ b/refnx/_lib/__init__.py
@@ -3,7 +3,7 @@ from __future__ import division, absolute_import
 import numpy.testing
 
 from refnx._lib.util import (TemporaryDirectory, preserve_cwd,
-                             possibly_open_file, possibly_create_pool)
+                             possibly_open_file, PoolWrapper)
 from refnx._lib._numdiff import approx_hess2
 
 from refnx._lib._testutils import PytestTester

--- a/refnx/analysis/curvefitter.py
+++ b/refnx/analysis/curvefitter.py
@@ -12,7 +12,7 @@ from scipy._lib._util import check_random_state
 from scipy.optimize import minimize, differential_evolution, least_squares
 
 from refnx.analysis import Objective, Interval, PDF, is_parameter
-from refnx._lib import (unique as f_unique, possibly_create_pool,
+from refnx._lib import (unique as f_unique, PoolWrapper,
                         possibly_open_file, flatten)
 from refnx._lib.util import getargspec
 
@@ -444,7 +444,7 @@ class CurveFitter(object):
         return np.transpose(acfs)
 
     def sample(self, steps, nthin=1, random_state=None, f=None, callback=None,
-               verbose=True, pool=0):
+               verbose=True, pool=-1):
         """
         Performs sampling from the objective.
 
@@ -472,7 +472,7 @@ class CurveFitter(object):
             Gives updates on the sampling progress
         pool : int or map-like object, optional
             If `pool` is an `int` then it specifies the number of threads to
-            use for parallelization. If `pool == 0`, then all CPU's are used.
+            use for parallelization. If `pool == -1`, then all CPU's are used.
             If pool is an object with a map method that follows the same
             calling sequence as the built-in map function, then this pool is
             used for parallelisation.
@@ -546,7 +546,7 @@ class CurveFitter(object):
 
         # using context manager means we kill off zombie pool objects
         # but does mean that the pool has to be specified each time.
-        with possibly_create_pool(pool) as g, possibly_open_file(f, 'a') as h:
+        with PoolWrapper(pool) as g, possibly_open_file(f, 'a') as h:
             # if you're not creating more than 1 thread, then don't bother with
             # a pool.
             if pool == 1:


### PR DESCRIPTION
Change to using a `PoolWrapper` class.

Backward incompatibility: change the default of `pool`  in the sampler. -1 now means all CPU's.