### PR TITLE
TST: remove uncertainties as a dependency

### DIFF
--- a/INSTALL_CONTRIBUTE.md
+++ b/INSTALL_CONTRIBUTE.md
@@ -9,7 +9,7 @@ Monte Carlo to obtain posterior distributions for curvefitting problems.
 
 *refnx* has been tested on Python 3.5, 3.6 and 3.7. It requires the *numpy,
 scipy, cython, pandas, emcee* packages to work. Additional features require the
-*pytest, h5py, xlrd, uncertainties, ptemcee, tqdm, matplotlib, pymc3* packages.
+*pytest, h5py, xlrd, ptemcee, tqdm, matplotlib, pymc3, theano* packages.
 To build the bleeding edge code you will need to have access to a C-compiler to
 build a couple of Python extensions. C-compilers should be installed on Linux.
 On OSX you will need to install Xcode and the command line tools. On Windows you
@@ -41,7 +41,7 @@ step is to create a *conda* environment.
   conda activate refnx
   ```
   3) Install the remaining dependencies:
-  ```pip install uncertainties ptemcee```
+  ```pip install ptemcee```
  
 ### Installing into a conda environment from source
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,8 +14,8 @@ jobs:
         python.version: '3.5'
       Python36:
         python.version: '3.6'
-      Python37:
-        python.version: '3.7'
+#      Python37:
+#        python.version: '3.7'
     maxParallel: 4
 
   steps:
@@ -24,7 +24,7 @@ jobs:
       versionSpec: '$(python.version)'
       architecture: 'x64'
 
-  - script: python -m pip install --upgrade pip && pip install numpy scipy cython traitlets ipython ipywidgets pandas h5py xlrd pytest tqdm corner matplotlib pymc3 uncertainties
+  - script: python -m pip install --upgrade pip && pip install numpy scipy cython traitlets ipython ipywidgets pandas h5py xlrd pytest tqdm corner matplotlib pymc3
     displayName: 'Install dependencies'
 
   - script: |

--- a/setup.py
+++ b/setup.py
@@ -142,12 +142,11 @@ info = {
         'include_package_data': True,
         'setup_requires': ['numpy'],
         'python_requires': '>=3.5',
-        'install_requires': ['numpy', 'scipy', 'six',
-                             'uncertainties', 'pandas'],
+        'install_requires': ['numpy', 'scipy', 'six', 'pandas'],
         'extras_require': {'all': ['IPython', 'ipywidgets', 'traitlets',
                                    'matplotlib', 'xlrd', 'h5py', 'tqdm',
                                    'pymc3', 'theano', 'ptemcee']},
-        'tests_require': ['pytest'],
+        'tests_require': ['pytest', 'uncertainties'],
         'cmdclass': {'test': PyTest},
         }
 


### PR DESCRIPTION
The `uncertainties` package is only required for testing, not for operation.