### PR TITLE
ENH: interactive modeller save/load buttons

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,3 +10,7 @@ Details of changes made to refnx
 - add `refnx.util.refplot` for quick plotting of reflectometry datasets
 - fixed various deprecation warnings
 - added the ability to mask (hide) points in a `refnx.dataset.Data1D` dataset
+
+0.1.2
+-----
+- added save/load model buttons in the interactive reflectometry modeller.


### PR DESCRIPTION
Adds save/load model buttons to the interactive modeller GUI. This modification is based on user experience - when the notebook is saved/loaded then the GUI doesn't maintain widget information (unless widget state is saved). This PR adds buttons that make it easier to (de)serialise models.