### PR TITLE
MAINT: remove pandas as a mandatory dependency

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -8,10 +8,10 @@ Installation
 .. _miniconda: https://conda.io/miniconda.html
 .. _github: https://github.com/refnx/refnx
 
-*refnx* has been tested on Python 2.7, 3.5, 3.6 and 3.7. It requires the
-*numpy, scipy, cython, pandas* packages to work. Additional features
+*refnx* has been tested on Python 3.5, 3.6 and 3.7. It requires the
+*numpy, scipy, cython* packages to work. Additional features
 require the *pytest, h5py, xlrd, uncertainties, ptemcee, matplotlib, Jupyter,*
-*ipywidgets, traitlets, tqdm* packages. To build the bleeding edge
+*ipywidgets, traitlets, tqdm, pandas* packages. To build the bleeding edge
 code you will need to have access to a C-compiler to build a couple of Python
 extensions. C-compilers should be installed on Linux. On OSX you will need to
 install Xcode and the command line tools. On Windows you will need to install

--- a/setup.py
+++ b/setup.py
@@ -142,10 +142,10 @@ info = {
         'include_package_data': True,
         'setup_requires': ['numpy'],
         'python_requires': '>=3.5',
-        'install_requires': ['numpy', 'scipy', 'pandas'],
+        'install_requires': ['numpy', 'scipy'],
         'extras_require': {'all': ['IPython', 'ipywidgets', 'traitlets',
                                    'matplotlib', 'xlrd', 'h5py', 'tqdm',
-                                   'pymc3', 'theano', 'ptemcee']},
+                                   'pymc3', 'theano', 'ptemcee', 'pandas']},
         'tests_require': ['pytest', 'uncertainties'],
         'cmdclass': {'test': PyTest},
         }


### PR DESCRIPTION
It's only needed for reduction, and it's noted in setup.py in the extras_require section.