### PR TITLE
ENH: adding MixedReflectModel to pyqt gui

### DIFF
--- a/refnx/reflect/_code_fragment.py
+++ b/refnx/reflect/_code_fragment.py
@@ -24,7 +24,8 @@ def code_fragment(objective):
     code.append("from refnx.dataset import ReflectDataset")
 
     code.append('from refnx.reflect import Slab, SLD, Structure')
-    code.append('from refnx.reflect import ReflectModel, LipidLeaflet')
+    code.append('from refnx.reflect import ReflectModel, LipidLeaflet,'
+                ' MixedReflectModel')
     code.append('from refnx._lib import flatten')
 
     code.append('import refnx')

--- a/refnx/reflect/reflect_model.py
+++ b/refnx/reflect/reflect_model.py
@@ -690,6 +690,12 @@ class MixedReflectModel(object):
 
         self._structures = structures
 
+    def __repr__(self):
+        s = ("MixedReflectModel({_structures!r}, scales={_scales!r},"
+             " bkg={_bkg!r}, name={name!r}, dq={_dq!r}, threads={threads!r},"
+             " quad_order={quad_order!r})")
+        return s.format(**self.__dict__)
+
     def __call__(self, x, p=None, x_err=None):
         r"""
         Calculate the generative model

--- a/refnx/reflect/test/test_reflect.py
+++ b/refnx/reflect/test/test_reflect.py
@@ -13,11 +13,14 @@ try:
 except ImportError:
     HAVE_CREFLECT = False
 
+# Before removing what appear to be unused imports think twice.
+# Some of the tests use eval, which requires the imports.
 import refnx.reflect._reflect as _reflect
 from refnx.analysis import (Transform, Objective,
-                            CurveFitter, Parameter)
+                            CurveFitter, Parameter, Interval,
+                            Parameters)
 from refnx.reflect import (SLD, ReflectModel, MixedReflectModel,
-                           reflectivity)
+                           reflectivity, Structure, Slab)
 from refnx.dataset import ReflectDataset
 
 
@@ -483,6 +486,14 @@ class TestReflect(object):
         assert_(mixed_model.dq.value == 0)
 
         assert_equal(mixed_model_y, mixed_model(self.qvals))
+
+        # test repr of MixedReflectModel
+        q = repr(mixed_model)
+        r = eval(q)
+        assert_equal(r.scales, np.array([0.4, 0.6]))
+        assert_(r.dq.value == 0)
+
+        assert_equal(mixed_model_y, r(self.qvals))
 
     def test_pnr(self):
         # test pnr calculation

--- a/refnx/reflect/test/test_reflect.py
+++ b/refnx/reflect/test/test_reflect.py
@@ -522,8 +522,6 @@ class TestReflect(object):
         assert_allclose(r[1], mm)
 
     def test_repr_reflect_model(self):
-        from refnx.reflect import Structure, Slab
-        from refnx.analysis import Interval
         p = SLD(0.)
         q = SLD(2.07)
         s = p(0, 0) | q(0, 3)


### PR DESCRIPTION
Adds the ability to form a mixed area model (based on MixedReflectModel) in the pyqt gui. When the user right clicks on a dataset they can add a structure to the model. The overall reflectivity is a scale factor weighted average of the different structures.