### PR TITLE
ENH: easy structure plot

### DIFF
--- a/refnx/analysis/test/test_curvefitter.py
+++ b/refnx/analysis/test/test_curvefitter.py
@@ -350,6 +350,11 @@ class TestFitterGauss(object):
         f.sample(steps=2, nthin=4, f=checkpoint, verbose=False)
         assert_equal(f.chain.shape[0], 2)
 
+        # we should be able to produce 2 * 100 steps from the generator
+        g = self.objective.pgen(ngen=20000000000)
+        s = [i for i, a in enumerate(g)]
+        assert_equal(np.max(s), 200 - 1)
+
         # the following test won't work because of emcee/gh226.
         # chain = load_chain(checkpoint)
         # assert_(chain.shape == f.chain.shape)

--- a/refnx/reflect/structure.py
+++ b/refnx/reflect/structure.py
@@ -362,6 +362,58 @@ class Structure(UserList):
 
         return logp
 
+    def plot(self, pvals=None, samples=0, fig=None):
+        """
+        Plot the structure.
+
+        Requires matplotlib be installed.
+
+        Parameters
+        ----------
+        pvals : np.ndarray, optional
+            Numeric values for the Parameter's that are varying
+        samples: number
+            If this structures constituent parameters have been sampled, how
+            many samples you wish to plot on the graph.
+        fig: Figure instance, optional
+            If `fig` is not supplied then a new figure is created. Otherwise
+            the graph is created on the current axes on the supplied figure.
+
+        Returns
+        -------
+        fig, ax : :class:`matplotlib.Figure`, :class:`matplotlib.Axes`
+          `matplotlib` figure and axes objects.
+
+      """
+        import matplotlib.pyplot as plt
+
+        params = self.parameters
+
+        if pvals is not None:
+            params.pvals = pvals
+
+        if fig is None:
+            fig = plt.figure()
+            ax = fig.add_subplot(111)
+        else:
+            ax = fig.gca()
+
+        if samples > 0:
+            saved_params = np.array(params)
+            # Get a number of chains, chosen randomly, and plot the model.
+            for pvec in self.parameters.pgen(ngen=samples):
+                params.pvals = pvec
+
+                ax.plot(*self.sld_profile(),
+                        color="k", alpha=0.01)
+
+            # put back saved_params
+            params.pvals = saved_params
+
+        ax.plot(*self.sld_profile(), color='red', zorder=20)
+
+        return fig, ax
+
 
 class SLD(object):
     """


### PR DESCRIPTION
This PR adds the `Structure.plot` method (matplotlib required to use it), to allow one to plot sld profiles for a given structure. If the Structural parameters have associated MCMC chains then it is possible to plot samples from those as well.

The code script generator (in the GUI) has been updated to enable the scripts to produce graphs of the MCMC sampling process. Graphs for the sld profiles and data/fits will be produced when the script is run.

The `Parameters` class is given a pgen method to allow it to yield samples from the chains contained in its varying parameters.