### PR TITLE
MAINT: slabs property --> slabs method

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -46,3 +46,7 @@ Details of changes made to refnx
   instead of multi-threaded.
 - Added MixedReflectModel to the pyqt GUI, allowing one to model 'patchy'
   systems, i.e. incoherent averaging of reflectivities.
+- BACKWARDS INCOMPATIBLE CHANGE: the slabs properties of `Component` and
+  `Structure` have now been changed to methods, taking the optional `structure`
+  kwd parameter. The reason for this is so each `Component` knows what kind of
+  `Structure` it is in.

--- a/examples/analytical_profiles/brushes/brush.py
+++ b/examples/analytical_profiles/brushes/brush.py
@@ -319,16 +319,15 @@ class FreeformVFPextent(Component):
         area = interpolator.integrate(0, 1) * float(self.extent)
 
         for slab in self.left_slabs:
-            _slabs = slab.slabs
+            _slabs = slab.slabs()
             area += _slabs[0, 0] * (1 - _slabs[0, 4])
         for slab in self.right_slabs:
-            _slabs = slab.slabs
+            _slabs = slab.slabs()
             area += _slabs[0, 0] * (1 - _slabs[0, 4])
 
         return area
 
-    @property
-    def slabs(self):
+    def slabs(self, structure=None):
         num_slabs = np.ceil(float(self.extent) / self.microslab_max_thickness)
         slab_thick = float(self.extent / num_slabs)
         slabs = np.zeros((int(num_slabs), 5))
@@ -365,8 +364,8 @@ class FreeformVFPextent(Component):
             layer.vfsolv.value = slab.vfsolv.value
             s |= layer
 
-        polymer_slabs = self.slabs
-        offset = np.sum(s.slabs[:, 0])
+        polymer_slabs = self.slabs()
+        offset = np.sum(s.slabs()[:, 0])
 
         for i in range(np.size(polymer_slabs, 0)):
             layer = m(polymer_slabs[i, 0], polymer_slabs[i, 3])
@@ -381,7 +380,7 @@ class FreeformVFPextent(Component):
         s |= SLD(0, 0)
 
         # now calculate the VFP.
-        total_thickness = np.sum(s.slabs[:, 0])
+        total_thickness = np.sum(s.slabs()[:, 0])
         zed = np.linspace(0, total_thickness, total_thickness + 1)
         # SLD profile puts a very small roughness on the interfaces with zero
         # roughness.
@@ -666,10 +665,10 @@ class FreeformVFPgamma(Component):
         """
         required_spline_area = float(self.gamma)
         for slab in self.left_slabs:
-            _slabs = slab.slabs
+            _slabs = slab.slabs()
             required_spline_area -= _slabs[0, 0] * (1 - _slabs[0, 4])
         for slab in self.right_slabs:
-            _slabs = slab.slabs
+            _slabs = slab.slabs()
             required_spline_area -= _slabs[0, 0] * (1 - _slabs[0, 4])
 
         if required_spline_area <= 0:
@@ -696,16 +695,15 @@ class FreeformVFPgamma(Component):
             area += interpolator.integrate(0, 1) * extent
 
         for slab in self.left_slabs:
-            _slabs = slab.slabs
+            _slabs = slab.slabs()
             area += _slabs[0, 0] * (1 - _slabs[0, 4])
         for slab in self.right_slabs:
-            _slabs = slab.slabs
+            _slabs = slab.slabs()
             area += _slabs[0, 0] * (1 - _slabs[0, 4])
 
         return area
 
-    @property
-    def slabs(self):
+    def slabs(self, structure=None):
         extent = self.extent
         if extent <= 0:
             return None
@@ -746,8 +744,8 @@ class FreeformVFPgamma(Component):
             layer.vfsolv.value = slab.vfsolv.value
             s |= layer
 
-        polymer_slabs = self.slabs
-        offset = np.sum(s.slabs[:, 0])
+        polymer_slabs = self.slabs()
+        offset = np.sum(s.slabs()[:, 0])
 
         if polymer_slabs is not None:
             for i in range(np.size(polymer_slabs, 0)):
@@ -763,7 +761,7 @@ class FreeformVFPgamma(Component):
         s |= SLD(0, 0)
 
         # now calculate the VFP.
-        total_thickness = np.sum(s.slabs[:, 0])
+        total_thickness = np.sum(s.slabs()[:, 0])
         zed = np.linspace(0, total_thickness, total_thickness + 1)
         # SLD profile puts a very small roughness on the interfaces with zero
         # roughness.

--- a/refnx/analysis/test/test_globalfitting.py
+++ b/refnx/analysis/test/test_globalfitting.py
@@ -130,9 +130,9 @@ class TestGlobalFitting(object):
         assert_almost_equal(global_chisqr, indiv_chisqr)
 
         # now check that the parameters were held in common correctly.
-        slabs361 = structure361.slabs
-        slabs365 = structure365.slabs
-        slabs366 = structure366.slabs
+        slabs361 = structure361.slabs()
+        slabs365 = structure365.slabs()
+        slabs366 = structure366.slabs()
 
         assert_equal(slabs365[0:2, 0:5], slabs361[0:2, 0:5])
         assert_equal(slabs366[0:2, 0:5], slabs361[0:2, 0:5])

--- a/refnx/reflect/_code_fragment.py
+++ b/refnx/reflect/_code_fragment.py
@@ -27,7 +27,7 @@ from refnx.analysis.parameter import _BinaryOp, _UnaryOp
 from refnx.dataset import ReflectDataset, Data1D
 
 from refnx.reflect import Slab, SLD, Structure
-from refnx.reflect import ReflectModel, LipidLeaflet, MixedReflectModel
+from refnx.reflect import ReflectModel, LipidLeaflet, MixedReflectModel, Spline
 from refnx._lib import flatten
 
 import refnx
@@ -35,7 +35,7 @@ import refnx
 """)
 
 
-_main = ("""
+_main = (r"""
 
 def structure_plot(obj, samples=0):
     # plot sld profiles
@@ -60,8 +60,8 @@ def structure_plot(obj, samples=0):
             if hasattr(o.model, 'structure'):
                 ax.plot(*o.model.structure.sld_profile(), zorder=20)
 
-        ax.set_ylabel('SLD / $10^{-6}\\AA^{-2}$')
-        ax.set_xlabel("z / $\\AA$")
+        ax.set_ylabel('SLD / $10^{-6}\AA^{-2}$')
+        ax.set_xlabel("z / $\AA$")
 
     elif isinstance(obj, Objective) and hasattr(obj.model, 'structure'):
         fig, ax = obj.model.structure.plot(samples=samples)
@@ -128,7 +128,7 @@ if __name__ == "__main__":
     try:
         fig, ax = obj.plot(samples=nplot)
         ax.set_ylabel('R')
-        ax.set_xlabel("Q / $\\AA$")
+        ax.set_xlabel("Q / $\AA$")
         fig.savefig('steps.png', dpi=1000)
 
         structure_plot(obj, samples=nplot)

--- a/refnx/reflect/_code_fragment.py
+++ b/refnx/reflect/_code_fragment.py
@@ -60,8 +60,8 @@ def structure_plot(obj, samples=0):
             if hasattr(o.model, 'structure'):
                 ax.plot(*o.model.structure.sld_profile(), zorder=20)
 
-        ax.set_ylabel('SLD / $10^{-6}\AA^{-2}$')
-        ax.set_xlabel("z / $\AA$")
+        ax.set_ylabel('SLD / $10^{-6}\\AA^{-2}$')
+        ax.set_xlabel("z / $\\AA$")
 
     elif isinstance(obj, Objective) and hasattr(obj.model, 'structure'):
         fig, ax = obj.model.structure.plot(samples=samples)
@@ -128,7 +128,7 @@ if __name__ == "__main__":
     try:
         fig, ax = obj.plot(samples=nplot)
         ax.set_ylabel('R')
-        ax.set_xlabel("Q / $\AA$")
+        ax.set_xlabel("Q / $\\AA$")
         fig.savefig('steps.png', dpi=1000)
 
         structure_plot(obj, samples=nplot)

--- a/refnx/reflect/_lipid.py
+++ b/refnx/reflect/_lipid.py
@@ -199,10 +199,14 @@ class LipidLeaflet(Component):
              " reverse_monolayer={reverse_monolayer}, name={name!r})")
         return s.format(**d)
 
-    @property
-    def slabs(self):
+    def slabs(self, structure=None):
         """
         Slab representation of monolayer, as an array
+
+        Parameters
+        ----------
+        structure : refnx.reflect.Structure
+            The Structure hosting this Component
         """
         layers = np.zeros((2, 5))
 

--- a/refnx/reflect/reflect_model.py
+++ b/refnx/reflect/reflect_model.py
@@ -180,7 +180,7 @@ class ReflectModel(object):
             # fallback to what this object was constructed with
             x_err = float(self.dq)
 
-        return reflectivity(x, self.structure.slabs[..., :4],
+        return reflectivity(x, self.structure.slabs()[..., :4],
                             scale=self.scale.value,
                             bkg=self.bkg.value,
                             dq=x_err,
@@ -788,7 +788,7 @@ class MixedReflectModel(object):
 
         for scale, structure in zip(scales, self.structures):
             y += reflectivity(x,
-                              structure.slabs[..., :4],
+                              structure.slabs()[..., :4],
                               scale=scale,
                               dq=x_err,
                               threads=self.threads,

--- a/refnx/reflect/structure.py
+++ b/refnx/reflect/structure.py
@@ -183,7 +183,6 @@ class Structure(UserList):
 
         Returns
         -------
-
         slabs : :class:`np.ndarray`
             Slab representation of this structure.
             Has shape (N, 5).

--- a/refnx/reflect/test/test__lipid.py
+++ b/refnx/reflect/test/test__lipid.py
@@ -30,7 +30,7 @@ class TestLipidLeaflet(object):
 
     def test_slabs(self):
         # check that slab calculation from parameters is correct
-        slabs = self.leaflet.slabs
+        slabs = self.leaflet.slabs()
         theoretical = np.array([[self.thick_h, self.rho_h, 0, 3,
                                  self.phi_solv_h],
                                 [self.thick_t, self.rho_t, 0, 2,
@@ -41,19 +41,19 @@ class TestLipidLeaflet(object):
         self.leaflet.reverse_monolayer = True
         theoretical = np.flipud(theoretical)
         theoretical[:, 3] = theoretical[::-1, 3]
-        assert_allclose(self.leaflet.slabs, theoretical, rtol=1e-15)
+        assert_allclose(self.leaflet.slabs(), theoretical, rtol=1e-15)
 
     def test_solvent_penetration(self):
         # check different types of solvation for heads/tails.
         self.leaflet.head_solvent = SLD(1.23)
-        slabs = self.leaflet.slabs
+        slabs = self.leaflet.slabs()
         assert_allclose(slabs[0, 1], 1.23 * self.phi_solv_h +
                         (1 - self.phi_solv_h) * self.rho_h)
         assert_allclose(slabs[0, 4], 0)
 
         self.leaflet.head_solvent = None
         self.leaflet.tail_solvent = SLD(1.23)
-        slabs = self.leaflet.slabs
+        slabs = self.leaflet.slabs()
         assert_allclose(slabs[1, 1], 1.23 * self.phi_solv_t +
                         (1 - self.phi_solv_t) * self.rho_t)
         assert_allclose(slabs[1, 4], 0)
@@ -66,12 +66,12 @@ class TestLipidLeaflet(object):
                                    heads, self.V_h, self.thick_h,
                                    tails, self.V_t, self.thick_t,
                                    2, 3)
-        slabs = self.leaflet.slabs
-        new_slabs = new_leaflet.slabs
+        slabs = self.leaflet.slabs()
+        new_slabs = new_leaflet.slabs()
         assert_allclose(new_slabs, slabs)
 
     def test_repr(self):
         # test that we can reconstruct the object from a repr
         s = repr(self.leaflet)
         q = eval(s)
-        assert_equal(q.slabs, self.leaflet.slabs)
+        assert_equal(q.slabs(), self.leaflet.slabs())

--- a/refnx/reflect/test/test_reflect.py
+++ b/refnx/reflect/test/test_reflect.py
@@ -82,23 +82,24 @@ class TestReflect(object):
     def test_c_abeles(self):
         if TEST_C_REFLECT:
             # test reflectivity calculation with values generated from Motofit
-            calc = _creflect.abeles(self.qvals, self.structure.slabs[..., :4])
+            calc = _creflect.abeles(self.qvals,
+                                    self.structure.slabs()[..., :4])
             assert_almost_equal(calc, self.rvals)
 
             # test for non-contiguous Q values
             tempq = self.qvals[0::5]
             assert_(tempq.flags['C_CONTIGUOUS'] is False)
-            calc = _creflect.abeles(tempq, self.structure.slabs[..., :4])
+            calc = _creflect.abeles(tempq, self.structure.slabs()[..., :4])
             assert_almost_equal(calc, self.rvals[0::5])
 
     def test_c_abeles_multithreaded(self):
         if TEST_C_REFLECT:
-            _creflect.abeles(self.qvals, self.structure.slabs[..., :4],
+            _creflect.abeles(self.qvals, self.structure.slabs()[..., :4],
                              threads=4)
 
     def test_py_abeles(self):
         # test reflectivity calculation with values generated from Motofit
-        calc = _reflect.abeles(self.qvals, self.structure.slabs[..., :4])
+        calc = _reflect.abeles(self.qvals, self.structure.slabs()[..., :4])
         assert_almost_equal(calc, self.rvals)
 
     def test_first_principles(self):
@@ -144,7 +145,7 @@ class TestReflect(object):
     def test_compare_c_py_abeles(self):
         # test python and c are equivalent
         # but not the same file
-        s = self.structure.slabs[..., :4]
+        s = self.structure.slabs()[..., :4]
 
         if not TEST_C_REFLECT:
             return
@@ -250,7 +251,7 @@ class TestReflect(object):
         structure = si | sio2(100, 3) | air(0, 2)
         structure.reverse_structure = True
 
-        assert_equal(structure.slabs, self.structure.slabs)
+        assert_equal(structure.slabs(), self.structure.slabs())
 
         calc = structure.reflectivity(self.qvals)
         assert_almost_equal(calc, self.rvals)
@@ -259,7 +260,7 @@ class TestReflect(object):
         # c reflectivity should be able to deal with multidimensional input
         if not TEST_C_REFLECT:
             return
-        s = self.structure.slabs[..., :4]
+        s = self.structure.slabs()[..., :4]
 
         reshaped_q = np.reshape(self.qvals, (2, 250))
         reshaped_r = self.rvals.reshape(2, 250)
@@ -269,7 +270,7 @@ class TestReflect(object):
 
     def test_abeles_reshape(self):
         # reflectivity should be able to deal with multidimensional input
-        s = self.structure.slabs[..., :4]
+        s = self.structure.slabs()[..., :4]
 
         reshaped_q = np.reshape(self.qvals, (2, 250))
         reshaped_r = self.rvals.reshape(2, 250)
@@ -415,7 +416,7 @@ class TestReflect(object):
     def test_resolution_kernel(self):
         # check that resolution kernel works, use constant dq/q of 5% as
         # comparison
-        slabs = self.structure361.slabs[:, :4]
+        slabs = self.structure361.slabs()[:, :4]
         npnts = 1000
         q = np.linspace(0.005, 0.3, npnts)
 
@@ -476,7 +477,7 @@ class TestReflect(object):
         model.scale.setp(vary=True, bounds=(0, 2))
         model.bkg.setp(vary=True, bounds=(0, 8e-6))
 
-        slabs = structure.slabs
+        slabs = structure.slabs()
         assert_equal(slabs[2, 0:2], slabs[3, 0:2])
         assert_equal(slabs[2, 3], slabs[3, 3])
         assert_equal(slabs[1, 3], sio2_l.rough.value)
@@ -484,7 +485,7 @@ class TestReflect(object):
         f = CurveFitter(objective)
         f.fit(method='differential_evolution', seed=1)
 
-        slabs = structure.slabs
+        slabs = structure.slabs()
         assert_equal(slabs[2, 0:2], slabs[3, 0:2])
         assert_equal(slabs[2, 3], slabs[3, 3])
 

--- a/refnx/reflect/test/test_spline.py
+++ b/refnx/reflect/test/test_spline.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy.testing import (assert_allclose, assert_equal, assert_almost_equal,
                            assert_)
 from refnx.reflect import SLD, Slab, Structure, Spline
-from refnx.analysis import Parameter
+from refnx.analysis import Parameter, Interval, Parameters
 from refnx._lib import flatten
 
 
@@ -16,22 +16,23 @@ class TestReflect(object):
     def test_spline_smoke(self):
         # smoke test to make Spline at least gives us something
         a = Spline(100, [2],
-                   [0.5], self.left, self.right, self.solvent, zgrad=False,
-                   microslab_max_thickness=1)
-        b = a.slabs
+                   [0.5], zgrad=False, microslab_max_thickness=1)
+
+        s = self.left | a | self.right | self.solvent
+        b = a.slabs(s)
         assert_equal(b[:, 2], 0)
 
         # microslabs are assessed in the middle of the slab
-        assert_equal(b[0, 1], a(0.5 * b[0, 0]))
+        assert_equal(b[0, 1], a(0.5 * b[0, 0], s))
 
         # with the ends turned off the profile should be a straight line
-        assert_equal(a(50), 2.0)
+        assert_equal(a(50, s), 2.0)
 
         # construct a structure
         a = Spline(100, [2., 3., 4.],
-                   [0.25] * 3, self.left, self.right, self.solvent,
-                   zgrad=False, microslab_max_thickness=1)
+                   [0.25] * 3, zgrad=False, microslab_max_thickness=1)
 
+        # s.solvent = None
         s = self.left | a | self.right | self.solvent
         # calculate an SLD profile
         s.sld_profile()
@@ -39,32 +40,84 @@ class TestReflect(object):
         for p in flatten(s.parameters):
             assert_(isinstance(p, Parameter))
 
+        # s.solvent is not None
+        s.solvent = self.solvent
+        # calculate an SLD profile
+        s.sld_profile()
+
+    def test_spline_solvation(self):
+        a = Spline(100, [2],
+                   [0.5], zgrad=False, microslab_max_thickness=1)
+
+        front = SLD(0.1)
+        air = SLD(0.0)
+        s = front | self.left | a | self.right | self.solvent
+
+        # assign a solvent
+        s.solvent = air
+        self.left.vfsolv.value = 0.5
+        self.right.vfsolv.value = 0.5
+        assert_equal(s.slabs()[1, 1], 0.75)
+        assert_equal(s.slabs()[-2, 1], 1.25)
+
+        assert_almost_equal(a(0, s), 0.75)
+        assert_almost_equal(a(100, s), 1.25)
+
+        # remove solvent, should be solvated by backing medium
+        s.solvent = None
+        assert_equal(s.slabs()[1, 1], 5.75)
+        assert_equal(s.slabs()[-2, 1], 6.25)
+        assert_almost_equal(a(0, s), 5.75)
+        assert_almost_equal(a(100, s), 6.25)
+
+        # reverse structure, should be solvated by fronting medium
+        s.reverse_structure = True
+        assert_equal(s.slabs()[1, 1], 1.3)
+        assert_equal(s.slabs()[-2, 1], 0.8)
+        # note that a(0, s) end becomes the end when the structure is reversed
+        assert_almost_equal(a(0, s), 0.8)
+        assert_almost_equal(a(100, s), 1.3)
+
     def test_left_right_influence(self):
         # make sure that if the left and right components change, so does the
         # spline
         a = Spline(100, [2],
-                   [0.5], self.left, self.right, self.solvent, zgrad=False,
-                   microslab_max_thickness=1)
+                   [0.5], zgrad=False, microslab_max_thickness=1)
+
+        s = self.left | a | self.right | self.solvent
 
         # change the SLD of the left component, spline should respond
         self.left.sld.real.value = 2.
-        assert_almost_equal(a(0), 2)
+        assert_almost_equal(a(0, s), 2)
 
-        # check that the spline responds if it's a vfsolve that changes
+        # check that the spline responds if it's a vfsolv that changes
         self.left.vfsolv.value = 0.5
-        assert_almost_equal(Structure.overall_sld(self.left.slabs,
+        assert_almost_equal(Structure.overall_sld(self.left.slabs(),
                                                   self.solvent)[0, 1],
                             6.)
-        assert_almost_equal(a(0), 6.)
+        assert_almost_equal(a(0, s), 6.)
 
         # check that the right side responds.
         self.right.sld.real.value = 5.
-        assert_almost_equal(a(100), 5.)
+        assert_almost_equal(a(100, s), 5.)
 
         # the spline should respond if the knot SLD's are changed
         a.vs[0].value = 3.
-        assert_almost_equal(a(50), 3.)
+        assert_almost_equal(a(50, s), 3.)
 
         # spline responds if the interval knot spacing is changed
         a.dz[0].value = 0.9
-        assert_almost_equal(a(90), 3.)
+        assert_almost_equal(a(90, s), 3.)
+
+    def test_repr(self):
+        # make sure that if the left and right components change, so does the
+        # spline
+        a = Spline(100, [2, 3, 4],
+                   [0.1, 0.2, 0.3], zgrad=False, microslab_max_thickness=1)
+
+        s = self.left | a | self.right | self.solvent
+
+        # should be able to repr the whole lot
+        q = repr(s)
+        r = eval(q)
+        assert_equal(r.slabs(), s.slabs())

--- a/refnx/reflect/test/test_structure.py
+++ b/refnx/reflect/test/test_structure.py
@@ -21,19 +21,37 @@ class TestStructure(object):
     def test_structure_construction(self):
         # structures are constructed by or-ing slabs
         # test that the slab representation is correct
-        assert_equal(self.s.slabs, np.array([[0, 0, 0, 0, 0],
-                                             [100, 3.47, 0, 5, 0],
-                                             [0, 6.36, 0, 4, 0]]))
+        assert_equal(self.s.slabs(), np.array([[0, 0, 0, 0, 0],
+                                              [100, 3.47, 0, 5, 0],
+                                              [0, 6.36, 0, 4, 0]]))
 
-        # slabs have solvent penetration
-        self.s.solvent = self.d2o
         self.s[1] = SLD(3.47 + 1j, name='sio2')(100, 5)
         self.s[1].vfsolv.value = 0.9
+
+        # slabs have solvent penetration
+        self.s.solvent = SLD(5 + 1.2j)
+        sld = 5 * 0.9 + 0.1 * 3.47
+        sldi = 1 * 0.1 + 0.9 * 1.2
+        assert_almost_equal(self.s.slabs(), np.array([[0, 0, 0, 0, 0],
+                                                      [100, sld, sldi, 5, 0.9],
+                                                      [0, 6.36, 0, 4, 0]]))
+
+        # by default solvation is done by backing medium
+        self.s.solvent = None
         sld = 6.36 * 0.9 + 0.1 * 3.47
         sldi = 1 * 0.1
-        assert_almost_equal(self.s.slabs, np.array([[0, 0, 0, 0, 0],
-                                                    [100, sld, sldi, 5, 0.9],
-                                                    [0, 6.36, 0, 4, 0]]))
+        assert_almost_equal(self.s.slabs(), np.array([[0, 0, 0, 0, 0],
+                                                     [100, sld, sldi, 5, 0.9],
+                                                     [0, 6.36, 0, 4, 0]]))
+
+        # by default solvation is done by backing medium, except when structure
+        # is reversed
+        self.s.reverse_structure = True
+        sld = 0 * 0.9 + 0.1 * 3.47
+        sldi = 0 * 0.9 + 1 * 0.1
+        assert_almost_equal(self.s.slabs(), np.array([[0, 6.36, 0, 0, 0],
+                                                      [100, sld, sldi, 4, 0.9],
+                                                      [0, 0, 0, 5, 0]]))
 
     def test_pickle(self):
         # need to be able to pickle and unpickle structure
@@ -98,6 +116,10 @@ class TestStructure(object):
         p = SLD(5 + 1j, name='pop')
         assert_equal(float(p.real), 5)
         assert_equal(float(p.imag), 1)
+
+        # test that we can cast to complex
+        assert_equal(complex(p), 5 + 1j)
+
         p = SLD(5)
         assert_equal(float(p.real), 5)
         q = Parameter(5)
@@ -116,10 +138,9 @@ class TestStructure(object):
         assert_allclose(round_trip_reflectivity, reflectivity, rtol=0.004)
 
     def test_slab_addition(self):
-        # The slabs property for the main Structure component constructs
-        # the overall slabs by concatenating Component slabs. It preallocates
-        # memory to prevent repeated memory allocations. This checks that the
-        # slab concatenation is correct.
+        # The slabs method for the main Structure component constructs
+        # the overall slabs by concatenating Component slabs. This checks that
+        # the slab concatenation is correct.
 
         si = SLD(2.07)
         sio2 = SLD(3.47)
@@ -128,12 +149,10 @@ class TestStructure(object):
         d2o_layer = d2o(0, 3)
         polymer_layer = polymer(20, 3)
         a = Spline(400, [4, 5.9],
-                   [0.2, .4], polymer_layer, d2o_layer, d2o, zgrad=True)
+                   [0.2, .4], zgrad=True)
         film = si | sio2(10, 3) | polymer_layer | a | d2o_layer
         film.sld_profile()
 
-        # the growth size is 100. Try and make 200 layers and check they were
-        # allocated correctly
         structure = si(0, 0)
         for i in range(200):
             p = SLD(i)(i, i)
@@ -141,7 +160,7 @@ class TestStructure(object):
 
         structure |= d2o(0, 3)
 
-        slabs = structure.slabs
+        slabs = structure.slabs()
         assert_equal(slabs[1:-1, 0], np.arange(200))
         assert_equal(slabs[1:-1, 1], np.arange(200))
         assert_equal(slabs[1:-1, 3], np.arange(200))

--- a/refnx/reflect/test/test_structure.py
+++ b/refnx/reflect/test/test_structure.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import (assert_almost_equal, assert_equal, assert_,
                            assert_allclose, assert_raises)
 
+from refnx._lib import flatten
 from refnx.reflect import (SLD, Structure, Spline, Slab)
 from refnx.reflect.structure import _profile_slicer
 from refnx.analysis import Parameter, Interval, Parameters
@@ -28,6 +29,8 @@ class TestStructure(object):
         self.s[1] = SLD(3.47 + 1j, name='sio2')(100, 5)
         self.s[1].vfsolv.value = 0.9
 
+        oldpars = len(list(flatten(self.s.parameters)))
+
         # slabs have solvent penetration
         self.s.solvent = SLD(5 + 1.2j)
         sld = 5 * 0.9 + 0.1 * 3.47
@@ -35,6 +38,11 @@ class TestStructure(object):
         assert_almost_equal(self.s.slabs(), np.array([[0, 0, 0, 0, 0],
                                                       [100, sld, sldi, 5, 0.9],
                                                       [0, 6.36, 0, 4, 0]]))
+
+        # when the structure._solvent is not None, but an SLD object, then
+        # it's number of parameters should increase by 2.
+        newpars = len(list(flatten(self.s.parameters)))
+        assert_equal(newpars, oldpars + 2)
 
         # by default solvation is done by backing medium
         self.s.solvent = None


### PR DESCRIPTION
This is a big changeset, and introduces a backwards incompatible change. The `Component.slabs` and `Structure.slabs` properties have been changed to methods, which take an optional `structure` kwd. The reason for this change is so that each `Component` knows what kind of structure it resides in. This is not important for standalone `Component`s, but if a `Component` depends on what's to its left or right, then it's vital.