### PR TITLE
ENH: drag and drop Components in pyqt GUI

### DIFF
--- a/refnx/reflect/_app/ui/motofit.ui
+++ b/refnx/reflect/_app/ui/motofit.ui
@@ -883,6 +883,9 @@ limits</string>
              <pointsize>12</pointsize>
             </font>
            </property>
+           <property name="acceptDrops">
+            <bool>true</bool>
+           </property>
            <property name="styleSheet">
             <string notr="true">QTreeView::branch:has-siblings:!adjoins-item {
     border-image: url(:/icons/vline.png) 0;
@@ -907,6 +910,24 @@ QTreeView::branch:open:has-children:has-siblings  {
         border-image: none;
         image: url(:/icons/branch-open.png);
 }</string>
+           </property>
+           <property name="editTriggers">
+            <set>QAbstractItemView::AnyKeyPressed|QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed|QAbstractItemView::SelectedClicked</set>
+           </property>
+           <property name="tabKeyNavigation">
+            <bool>false</bool>
+           </property>
+           <property name="dragEnabled">
+            <bool>true</bool>
+           </property>
+           <property name="dragDropMode">
+            <enum>QAbstractItemView::InternalMove</enum>
+           </property>
+           <property name="defaultDropAction">
+            <enum>Qt::MoveAction</enum>
+           </property>
+           <property name="alternatingRowColors">
+            <bool>false</bool>
            </property>
            <property name="selectionMode">
             <enum>QAbstractItemView::ExtendedSelection</enum>

--- a/refnx/reflect/_app/ui/motofit.ui
+++ b/refnx/reflect/_app/ui/motofit.ui
@@ -912,7 +912,7 @@ QTreeView::branch:open:has-children:has-siblings  {
 }</string>
            </property>
            <property name="editTriggers">
-            <set>QAbstractItemView::AnyKeyPressed|QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed|QAbstractItemView::SelectedClicked</set>
+            <set>QAbstractItemView::AnyKeyPressed|QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
            </property>
            <property name="tabKeyNavigation">
             <bool>false</bool>

--- a/refnx/reflect/_app/view.py
+++ b/refnx/reflect/_app/view.py
@@ -110,6 +110,7 @@ class MotofitMainWindow(QtWidgets.QMainWindow):
 
         self.treeModel.dataChanged.connect(self.tree_model_data_changed)
         self.treeModel.rowsRemoved.connect(self.tree_model_structure_changed)
+        self.treeModel.rowsMoved.connect(self.tree_model_structure_changed)
         self.treeModel.rowsInserted.connect(self.tree_model_structure_changed)
         #######################################################################
 


### PR DESCRIPTION
Allows one to drag and drop Components in a Structure. Within a Structure this has the effect of reordering Components. When moving to another Structure the component is copied to the new structure.