### PR TITLE
ENH: only show pars/data being fitted

### DIFF
--- a/refnx/reflect/_app/treeview_gui_model.py
+++ b/refnx/reflect/_app/treeview_gui_model.py
@@ -1007,9 +1007,13 @@ class TreeModel(QtCore.QAbstractItemModel):
 
 
 class TreeFilter(QtCore.QSortFilterProxyModel):
-    def __init__(self, tree_model, parent=None):
+    def __init__(self, tree_model, parent=None, only_fitted=False):
         super(TreeFilter, self).__init__(parent)
         self.tree_model = tree_model
+        # only_fitted means that only the entries that are varying will be
+        # displayed.
+        self.only_fitted = only_fitted
+        self._fitted_datasets = []
 
     def filterAcceptsRow(self, row, index):
         idx = self.tree_model.index(row, 0, index)
@@ -1047,6 +1051,15 @@ class TreeFilter(QtCore.QSortFilterProxyModel):
             if component_loc == 0 and row in [0, 2, 3, 4]:
                 return False
             if component_loc == len(struc.structure) - 1 and row in [0, 4]:
+                return False
+
+        # only_fitted means that only varying parameters should be displayed
+        if self.only_fitted:
+            # you have to be in the currently fitting list to be shown
+            dataset = find_data_object(idx).data_object
+            if dataset.name not in self._fitted_datasets:
+                return False
+            if isinstance(item, ParNode) and item._data.vary is False:
                 return False
 
         return True

--- a/refnx/reflect/_app/ui/motofit.ui
+++ b/refnx/reflect/_app/ui/motofit.ui
@@ -662,7 +662,7 @@
    </attribute>
    <widget class="QWidget" name="dockWidgetContents">
     <layout class="QGridLayout" name="gridLayout">
-     <item row="1" column="0">
+     <item row="0" column="0">
       <widget class="QTabWidget" name="tabWidget">
        <property name="enabled">
         <bool>true</bool>
@@ -696,52 +696,6 @@
          <string>Data and Model Trees</string>
         </attribute>
         <layout class="QGridLayout" name="gridLayout_2">
-         <item row="4" column="2">
-          <widget class="QPushButton" name="auto_limits_button">
-           <property name="minimumSize">
-            <size>
-             <width>60</width>
-             <height>60</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>70</width>
-             <height>70</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Give varying parameters finite limits</string>
-           </property>
-           <property name="text">
-            <string>Auto
-adjust
-limits</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="2">
-          <widget class="QPushButton" name="remove_from_fit_button">
-           <property name="minimumSize">
-            <size>
-             <width>60</width>
-             <height>60</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>70</width>
-             <height>70</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Remove dataset from those being fitted</string>
-           </property>
-           <property name="text">
-            <string>&lt;-</string>
-           </property>
-          </widget>
-         </item>
          <item row="1" column="3">
           <widget class="QPushButton" name="do_fit_button">
            <property name="sizePolicy">
@@ -780,20 +734,6 @@ limits</string>
            </property>
            <property name="shortcut">
             <string>Ctrl+F</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="2">
-          <widget class="QCheckBox" name="use_errors_checkbox">
-           <property name="text">
-            <string>Use
-errors?</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-           <property name="tristate">
-            <bool>false</bool>
            </property>
           </widget>
          </item>
@@ -837,28 +777,6 @@ errors?</string>
            </property>
            <property name="tickPosition">
             <enum>QSlider::NoTicks</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="2">
-          <widget class="QPushButton" name="add_to_fit_button">
-           <property name="minimumSize">
-            <size>
-             <width>60</width>
-             <height>60</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>70</width>
-             <height>70</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Add a dataset to those being fitted</string>
-           </property>
-           <property name="text">
-            <string>-&gt;</string>
            </property>
           </widget>
          </item>
@@ -1019,17 +937,111 @@ QTreeView::branch:open:has-children:has-siblings  {
            </attribute>
           </widget>
          </item>
+         <item row="1" column="2">
+          <widget class="QPushButton" name="add_to_fit_button">
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>60</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>70</width>
+             <height>70</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Add a dataset to those being fitted</string>
+           </property>
+           <property name="text">
+            <string>-&gt;</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QPushButton" name="remove_from_fit_button">
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>60</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>70</width>
+             <height>70</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Remove dataset from those being fitted</string>
+           </property>
+           <property name="text">
+            <string>&lt;-</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="QPushButton" name="auto_limits_button">
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>60</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>70</width>
+             <height>70</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Give varying parameters finite limits</string>
+           </property>
+           <property name="text">
+            <string>Auto
+adjust
+limits</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="2">
+          <widget class="QCheckBox" name="use_errors_checkbox">
+           <property name="text">
+            <string>Use
+errors?</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+           <property name="tristate">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="2">
+          <widget class="QCheckBox" name="only_fitted">
+           <property name="toolTip">
+            <string>Only display the parameters that are being allowed to vary.</string>
+           </property>
+           <property name="text">
+            <string>Only show
+varying?</string>
+           </property>
+          </widget>
+         </item>
         </layout>
-        <zorder>auto_limits_button</zorder>
         <zorder>remove_layer</zorder>
         <zorder>add_layer</zorder>
         <zorder>paramsSlider</zorder>
-        <zorder>use_errors_checkbox</zorder>
         <zorder>do_fit_button</zorder>
-        <zorder>remove_from_fit_button</zorder>
-        <zorder>add_to_fit_button</zorder>
         <zorder>treeView</zorder>
         <zorder>currently_fitting</zorder>
+        <zorder>add_to_fit_button</zorder>
+        <zorder>remove_from_fit_button</zorder>
+        <zorder>auto_limits_button</zorder>
+        <zorder>use_errors_checkbox</zorder>
+        <zorder>only_fitted</zorder>
        </widget>
        <widget class="QWidget" name="tab_1">
         <attribute name="title">
@@ -1353,16 +1365,11 @@ QTreeView::branch:open:has-children:has-siblings  {
   </action>
  </widget>
  <tabstops>
-  <tabstop>tabWidget</tabstop>
   <tabstop>treeView</tabstop>
   <tabstop>paramsSlider</tabstop>
   <tabstop>add_layer</tabstop>
   <tabstop>remove_layer</tabstop>
   <tabstop>do_fit_button</tabstop>
-  <tabstop>add_to_fit_button</tabstop>
-  <tabstop>remove_from_fit_button</tabstop>
-  <tabstop>auto_limits_button</tabstop>
-  <tabstop>use_errors_checkbox</tabstop>
   <tabstop>currently_fitting</tabstop>
   <tabstop>console_text_edit</tabstop>
  </tabstops>

--- a/refnx/reflect/_app/view.py
+++ b/refnx/reflect/_app/view.py
@@ -1103,6 +1103,16 @@ class MotofitMainWindow(QtWidgets.QMainWindow):
         self.redraw_data_object_graphs(data_objects)
 
     @QtCore.pyqtSlot(int)
+    def on_only_fitted_stateChanged(self, arg_1):
+        """
+        only display fitted parameters
+        """
+        self.treeFilter.only_fitted = arg_1
+        self.treeFilter._fitted_datasets = (
+            self.currently_fitting_model.datasets)
+        self.treeFilter.invalidateFilter()
+
+    @QtCore.pyqtSlot(int)
     def on_use_errors_checkbox_stateChanged(self, arg_1):
         """
         want to weight by error bars, recalculate chi2


### PR DESCRIPTION
This PR adds a filter to the refnx GUI so that the user can choose to display only the parameters/datasets being fitted. This makes it easier to distinguish the fitted parameters from the non-fitted parameters.