### PR TITLE
Auto update constrained parameters in refnx GUI

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -83,3 +83,10 @@ Details of changes made to refnx
 
 0.1.6
 -----
+- When parameters are linked in the refnx GUI only the dataset containing the
+  master parameter was being updated (reflectivity/SLD curves) when the master
+  was changed. Now all datasets that have parameters linked to the master
+  parameter (a constraint) are updated.
+- When a dataset/component/structure containing a master parameter (i.e. a
+  parameter to which other parameters are constrained to) is removed, the GUI
+  now unlinks those dependent parameters from the master parameter.

--- a/refnx/analysis/test/test_parameter.py
+++ b/refnx/analysis/test/test_parameter.py
@@ -55,7 +55,7 @@ class TestParameter(object):
         # z = x + y --> z = x + 2*x
         # therefore y shouldn't be in z's dependencies, but x should be.
         assert(x in z.dependencies())
-        assert(not y in z.dependencies())
+        assert(y not in z.dependencies())
 
         # absolute value constraint
         y.constraint = abs(x)

--- a/refnx/analysis/test/test_parameter.py
+++ b/refnx/analysis/test/test_parameter.py
@@ -20,8 +20,16 @@ class TestParameter(object):
         # simple test of constraint
         x = Parameter(5.)
         y = Parameter(1.)
+
+        y.constraint = x
+        assert(x in y.dependencies())
+
         y.constraint = x * 2.
         assert_equal(y.value, x.value * 2.)
+
+        # parameter should be in y's dependencies
+        assert(x in y._deps)
+        assert(x in y.dependencies())
 
         # if you've constrained a parameter it shouldn't be varying
         assert_(y.vary is False)
@@ -43,6 +51,11 @@ class TestParameter(object):
         # check that nested circular constraints aren't allowed
         with raises(ValueError):
             x.constraint = z
+
+        # z = x + y --> z = x + 2*x
+        # therefore y shouldn't be in z's dependencies, but x should be.
+        assert(x in z.dependencies())
+        assert(not y in z.dependencies())
 
         # absolute value constraint
         y.constraint = abs(x)

--- a/refnx/reflect/_app/view.py
+++ b/refnx/reflect/_app/view.py
@@ -1574,7 +1574,9 @@ class MotofitMainWindow(QtWidgets.QMainWindow):
             wipe_update = [find_data_object(top_left).data_object]
 
             # find if there are dependent parameters on the original
-            # parameter
+            # parameter. There's an argument for doing this in the treeModel,
+            # the model is normally responsible for manipulating data. However,
+            # if we do it here then we only need to redraw once.
             ds = self.treeModel.datastore
             for do in ds:
                 model = do.model

--- a/refnx/reflect/_app/view.py
+++ b/refnx/reflect/_app/view.py
@@ -882,6 +882,8 @@ class MotofitMainWindow(QtWidgets.QMainWindow):
         if isinstance(host, StructureNode) and idx in [0, len(host._data) - 1]:
             return msg("You can't remove the fronting or backing media")
 
+        # TODO: unlink any parameters that might depend on this component?
+
         # all checking done, remove a layer
         host.remove_component(idx)
 
@@ -1566,14 +1568,26 @@ class MotofitMainWindow(QtWidgets.QMainWindow):
 
         # only redraw if you're altering values
         # otherwise we'd be performing continual updates of the model
-        if top_left.column() != 1:
-            return
+        if (top_left.column() == 1 and isinstance(node, ParNode) and
+                len(role) and role[0] == QtCore.Qt.EditRole):
+            param = node.parameter
+            wipe_update = [find_data_object(top_left).data_object]
 
-        hierarchy = node.hierarchy()
-        for n in hierarchy:
-            if isinstance(n, DataObjectNode):
-                self.clear_data_object_uncertainties([n.data_object])
-                self.update_gui_model([n.data_object])
+            # find if there are dependent parameters on the original
+            # parameter
+            ds = self.treeModel.datastore
+            for do in ds:
+                model = do.model
+                cpars = model.parameters.constrained_parameters()
+                for cpar in cpars:
+                    deps = cpar.dependencies()
+                    if param in deps:
+                        wipe_update.append(do)
+                        break
+
+            wipe_update = list(unique(wipe_update))
+            self.clear_data_object_uncertainties(wipe_update)
+            self.update_gui_model(wipe_update)
 
     def calculate_chi2(self, data_objects):
         # calculate chi2 for all the data objects


### PR DESCRIPTION
If parameters are linked across datasets then the parameters all update in the tree model. However, only the dataset containing the master parameter would have its reflectivity recalculated.

This PR makes sure that the datasets containing the constrained parameters also get updated.