### PR TITLE
ENH: approximate box bounds for PDF

### DIFF
--- a/refnx/analysis/curvefitter.py
+++ b/refnx/analysis/curvefitter.py
@@ -538,8 +538,8 @@ class CurveFitter(object):
     def fit(self, method='L-BFGS-B', target='nll', **kws):
         """
         Obtain the maximum log-likelihood, or log-posterior, estimate (mode)
-        of the objective. For a least-squares objective maximum log-likelihood
-        corresponds to lowest chi2.
+        of the objective. Maximising the log-likelihood is equivalent to
+        minimising chi2 in a least squares fit.
 
         Parameters
         ----------
@@ -556,13 +556,22 @@ class CurveFitter(object):
 
             You can also choose many of the minimizers from
             ``scipy.optimize.minimize``.
+
         target : {'nll', 'nlpost'}, optional
             Minimize the negative log-likelihood (`'nll'`) or the negative
             log-posterior (`'nlpost'`). This is equivalent to maximising the
             likelihood or posterior probabilities respectively.
+            Maximising the likelihood is equivalent to minimising chi^2 in a
+            least-squares fit.
             This option only applies to the `differential_evolution`, `shgo`,
-            `dual_annealing` or `L-BFGS-B` options.
-            Have prior probabilities been defined that should be considered?
+            `dual_annealing` or `L-BFGS-B` methods.
+            These optimisers require lower and upper (box) bounds for each
+            parameter. If the `Bounds` on a parameter are not an `Interval`,
+            but a `PDF` specifying a statistical distribution, then the lower
+            and upper bounds are approximated as
+            ``PDF.rv.ppf([0.005, 0.995])``, covering 99 % of the statistical
+            distribution.
+
         kws : dict
             Additional arguments are passed to the underlying minimization
             method.
@@ -857,7 +866,22 @@ def uncertainty_from_chain(chain):
 
 def bounds_list(parameters):
     """
-    Return (interval) bounds for all varying parameters
+    Approximates interval bounds for a parameter set.
+
+    Parameters
+    ----------
+    parameters : sequence
+        A sequence containing individual parameters
+
+    Returns
+    -------
+    bounds: tuple
+        ``(min, max)`` pairs that define the finite lower and upper bounds
+        every element in ``parameters``.
+
+    If the `Bounds` applied by a parameter are a `PDF` instance then the upper
+    and lower bound are approximated by ``PDF.rv.ppf([0.005, 0.995])``, which
+    covers 99% of the statistical distribution.
     """
     bounds = []
     for param in parameters:
@@ -865,7 +889,12 @@ def bounds_list(parameters):
                 isinstance(param.bounds, Interval)):
             bnd = param.bounds
             bounds.append((bnd.lb, bnd.ub))
-        # TODO could also do any truncated PDF
+        elif (hasattr(param, 'bounds') and isinstance(param.bounds, PDF) and
+            hasattr(param.bounds.rv, 'ppf')):
+            bounds.append(param.bounds.rv.ppf([0.005, 0.995]))
+        else:
+            # We can't handle this bound
+            bounds.append((-np.inf, np.inf))
 
     return bounds
 

--- a/refnx/analysis/curvefitter.py
+++ b/refnx/analysis/curvefitter.py
@@ -890,7 +890,7 @@ def bounds_list(parameters):
             bnd = param.bounds
             bounds.append((bnd.lb, bnd.ub))
         elif (hasattr(param, 'bounds') and isinstance(param.bounds, PDF) and
-            hasattr(param.bounds.rv, 'ppf')):
+              hasattr(param.bounds.rv, 'ppf')):
             bounds.append(param.bounds.rv.ppf([0.005, 0.995]))
         else:
             # We can't handle this bound

--- a/refnx/analysis/objective.py
+++ b/refnx/analysis/objective.py
@@ -126,7 +126,7 @@ class BaseObjective(object):
         if pvals is not None:
             vals = pvals
 
-            logpost = self.logp(vals)
+        logpost = self.logp(vals)
         if not np.isfinite(logpost):
             return -np.inf
         logpost += self.logl(vals)

--- a/refnx/analysis/test/test_curvefitter.py
+++ b/refnx/analysis/test/test_curvefitter.py
@@ -430,8 +430,9 @@ class TestFitterGauss(object):
             res = f.fit(method=method)
             assert_almost_equal(res.x, self.best_weighted, 3)
 
-        res = f.fit(method='differential_evolution', target='lnpost', popsize=5)
-        assert_almost_equal(res.x, self.best_weighted, 3)
+        # smoke test to check that we can use nlpost
+        self.objective.setp(self.p0)
+        res = f.fit(method='differential_evolution', target='nlpost')
 
 
 """

--- a/refnx/analysis/test/test_curvefitter.py
+++ b/refnx/analysis/test/test_curvefitter.py
@@ -3,13 +3,16 @@ import pickle
 
 import numpy as np
 import scipy.optimize as sciopt
+from scipy.stats import norm
+
 import pytest
 from numpy.testing import (assert_, assert_almost_equal, assert_equal,
                            assert_allclose)
 
 from refnx.analysis import (CurveFitter, Parameter, Parameters, Model,
-                            Objective, process_chain, load_chain)
-from refnx.analysis.curvefitter import _HAVE_PTSAMPLER
+                            Objective, process_chain, load_chain, Bounds,
+                            PDF)
+from refnx.analysis.curvefitter import _HAVE_PTSAMPLER, bounds_list
 from refnx.dataset import Data1D
 from refnx._lib import emcee
 
@@ -66,6 +69,16 @@ class TestCurveFitter(object):
         self.mod = mod
 
         self.mcfitter = CurveFitter(self.objective)
+
+    def test_bounds_list(self):
+        bnds = bounds_list(self.p)
+        assert_allclose(bnds, [(-100, 100), (-100, 100)])
+
+        # try making a Parameter bound a normal distribution, then get an
+        # approximation to box bounds
+        self.p[0].bounds = PDF(norm(0, 1))
+        assert_allclose(bounds_list(self.p),
+                        [norm(0, 1).ppf([0.005, 0.995]), (-100, 100)])
 
     def test_constraints(self):
         # constraints should work during fitting
@@ -416,6 +429,9 @@ class TestFitterGauss(object):
             self.objective.setp(self.p0)
             res = f.fit(method=method)
             assert_almost_equal(res.x, self.best_weighted, 3)
+
+        res = f.fit(method='differential_evolution', target='lnpost', popsize=5)
+        assert_almost_equal(res.x, self.best_weighted, 3)
 
 
 """

--- a/refnx/analysis/test/test_curvefitter.py
+++ b/refnx/analysis/test/test_curvefitter.py
@@ -457,8 +457,8 @@ class TestFitterGauss(object):
         nll2 = self.objective.nll()
         nlpost2 = self.objective.nlpost()
 
-        assert_allclose(nlpost1, nlpost2)
-        assert_allclose(nll1, nll2)
+        assert_allclose(nlpost1, nlpost2, atol=0.001)
+        assert_allclose(nll1, nll2, atol=0.001)
 
         # these two priors are calculated for different parameter values
         # (before and after the fit) they should be the same because all

--- a/refnx/analysis/test/test_objective.py
+++ b/refnx/analysis/test/test_objective.py
@@ -135,6 +135,9 @@ class TestObjective(object):
         # http://dan.iel.fm/emcee/current/user/line/
         assert_almost_equal(self.objective.logp(), 0)
 
+        assert_almost_equal(self.objective.nlpost(),
+                            -self.objective.logpost())
+
         # the uncertainties are underestimated in this example...
         # amendment factor because dfm emcee example does not include 2pi
         amend = 0.5 * self.objective.npoints * np.log(2 * np.pi)


### PR DESCRIPTION
Building on @arm61 work, this PR approximates box bounds for a parameter whose prior is specified by a `PDF` object. These are typically statistical distributions - estimate lower and upper bounds for those as `PDF.rv.ppf([0.005, 0.995])`, which covers 99% of the distribution.