### PR TITLE
ENH: static autocorrelation_chain function

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -106,3 +106,9 @@ Details of changes made to refnx
 - Fixed bug in export of MCMC code fragment, Gui would crash.
 - Autocorrelation plot produced from mcmc.py code fragment, this can be used to
   judge how much to thin the chains by.
+- `refnx.analysis` now possesses a standalone function, `autocorrelation_chain`
+  for calculating chain autocorrelation. Previously the calculation had to be
+  done using a CurveFitter instance.
+- Function for calculating autocorrelation time made visible as:
+  `refnx.analysis.integrated_time`. You should pass the autocorrelation array
+  to this function.

--- a/refnx/analysis/__init__.py
+++ b/refnx/analysis/__init__.py
@@ -5,7 +5,8 @@ from refnx.analysis.objective import (Objective, BaseObjective,
                                       GlobalObjective, Transform,
                                       pymc_objective)
 from refnx.analysis.curvefitter import (CurveFitter, MCMCResult, process_chain,
-                                        load_chain)
+                                        load_chain, autocorrelation_chain)
+from refnx._lib.emcee.autocorr import integrated_time
 from refnx.analysis.model import Model, fitfunc
 
 

--- a/refnx/analysis/test/test_curvefitter.py
+++ b/refnx/analysis/test/test_curvefitter.py
@@ -11,7 +11,7 @@ from numpy.testing import (assert_, assert_almost_equal, assert_equal,
 
 from refnx.analysis import (CurveFitter, Parameter, Parameters, Model,
                             Objective, process_chain, load_chain, Bounds,
-                            PDF)
+                            PDF, autocorrelation_chain, integrated_time)
 from refnx.analysis.curvefitter import _HAVE_PTSAMPLER, bounds_list
 from refnx.dataset import Data1D
 from refnx._lib import emcee
@@ -128,6 +128,13 @@ class TestCurveFitter(object):
         # check that the autocorrelation function at least runs
         acfs = mcfitter.acf(nburn=10)
         assert_equal(acfs.shape[-1], mcfitter.nvary)
+
+        # check the standalone autocorrelation calculator
+        acfs2 = autocorrelation_chain(mcfitter.chain, nburn=10)
+        assert_equal(acfs, acfs2)
+
+        # check integrated_time
+        integrated_time(acfs2, tol=5)
 
         # check chain shape
         assert_equal(mcfitter.chain.shape, (33, 50, 2))

--- a/refnx/reflect/_code_fragment.py
+++ b/refnx/reflect/_code_fragment.py
@@ -221,7 +221,8 @@ if __name__ == "__main__":
                         type=int, default=0),
     parser.add_argument('-c', '--chain', help='initialise chain from file',
                         type=str, default='')
-    parser.add_argument('-v', '--verbose', help='verbose output',
+    parser.add_argument('-v', '--verbose', help="Displays a progress bar while"
+                        " sampling",
                         dest='verbose', action='store_true',  default=False)
 
     group = parser.add_mutually_exclusive_group()


### PR DESCRIPTION
Adds `autocorrelation_chain` and `integrated_time` to the `refnx.analysis` module. These are used to calculate the autocorrelation function and autocorrelation time of the sampled chain.