### PR TITLE
BUG: load already loaded dataset

### DIFF
--- a/refnx/reflect/_app/datastore.py
+++ b/refnx/reflect/_app/datastore.py
@@ -83,6 +83,7 @@ class DataStore(object):
             # was probably already read in self.load. Consider setting
             # the data by copying it from do.
             self.data_objects[do.name].refresh()
+            do = self.data_objects[do.name]
         else:
             self.data_objects[do.name] = do
 


### PR DESCRIPTION
If a dataset was already loaded, then loading it again caused a crash. This was because the model associated with the dataset was wiped.