### PR TITLE
MAINT: give informative message when experiment load fails

### DIFF
--- a/refnx/reflect/_app/view.py
+++ b/refnx/reflect/_app/view.py
@@ -215,6 +215,7 @@ class MotofitMainWindow(QtWidgets.QMainWindow):
         state['datastore'] = self.treeModel.datastore
         state['history'] = self.ui.console_text_edit.toPlainText()
         state['settings'] = self.settings
+        state['refnx.version'] = refnx.version.version
 
         fit_list = self.currently_fitting_model
         state['currently_fitting'] = fit_list.datasets
@@ -253,17 +254,25 @@ class MotofitMainWindow(QtWidgets.QMainWindow):
             print("Couldn't load experiment")
             return
 
-        self.treeModel._data = state[
-            'datastore']
-        self.treeModel.rebuild()
+        try:
+            self.treeModel._data = state[
+                'datastore']
+            self.treeModel.rebuild()
 
-        # remove and add datasetsToGraphs
-        self.reflectivitygraphs.remove_traces()
-        self.sldgraphs.remove_traces()
-        ds = [d for d in self.treeModel.datastore]
-        self.add_data_objects_to_graphs(ds)
-        self.update_gui_model(ds)
-        self.reflectivitygraphs.draw()
+            # remove and add datasetsToGraphs
+            self.reflectivitygraphs.remove_traces()
+            self.sldgraphs.remove_traces()
+            ds = [d for d in self.treeModel.datastore]
+            self.add_data_objects_to_graphs(ds)
+            self.update_gui_model(ds)
+            self.reflectivitygraphs.draw()
+        except Exception as e:
+            version = state.get('refnx.version', 'N/A')
+            msg("Failed to load experiment. It may have been saved in a"
+                " previous refnx version ({}). Please use that version to"
+                " continue with analysis, refnx will now"
+                " close.".format(version))
+            raise e
 
         try:
             self.ui.console_text_edit.setPlainText(state['history'])


### PR DESCRIPTION
When extra attributes are added to classes it's likely this will cause the refnx gui to be unable to load experiments saved in a previous version of refnx, because those attributes won't be present when objects are unpickled. It's possible to jump through hoops to try to prevent this (by controlling unpickling), but it makes classes ugly.
In the meantime produce an informative message that tells the user to go back to a previous version of refnx to start with.