### PR TITLE
MAINT: make gui more resistant to missing attributes when loading experiment file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
     - source activate conda-refnx
     - conda install --yes numpy scipy h5py cython pandas xlrd flake8 pytest ipywidgets IPython matplotlib traitlets pyqt
     - conda install --yes numpydoc sphinx jupyter pandoc nbconvert
-    - pip install uncertainties ptemcee corner nbsphinx jupyter-sphinx sphinx_rtd_theme tqdm pytest-qt periodictable
+    - pip install uncertainties ptemcee corner nbsphinx jupyter_sphinx sphinx_rtd_theme tqdm pytest-qt periodictable
     - pip install git+https://github.com/pymc-devs/pymc3
 
     # gradually expand flake8 to all of codebase

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -38,7 +38,7 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
     'nbsphinx',
-    'jupyter_sphinx.embed_widgets'
+    'jupyter_sphinx.execute'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -57,7 +57,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'refnx'
-copyright = '2015-2017, Andrew Nelson'
+copyright = '2015-2019, Andrew Nelson'
 author = 'Andrew Nelson'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - pandas
   - pip:
     - nbsphinx
-    - jupyter_sphinx
+    - jupyter-sphinx
     - sphinx_rtd_theme
     - tqdm
     - corner

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - pandas
   - pip:
     - nbsphinx
-    - jupyter-sphinx
+    - jupyter_sphinx
     - sphinx_rtd_theme
     - tqdm
     - corner

--- a/refnx/reflect/_app/view.py
+++ b/refnx/reflect/_app/view.py
@@ -259,6 +259,10 @@ class MotofitMainWindow(QtWidgets.QMainWindow):
                 'datastore']
             self.treeModel.rebuild()
 
+            # amend the internal state to compensate for mtft files saved in
+            # older versions missing attributes saved in later versions.
+            self.compensate_older_versions()
+
             # remove and add datasetsToGraphs
             self.reflectivitygraphs.remove_traces()
             self.sldgraphs.remove_traces()
@@ -306,6 +310,23 @@ class MotofitMainWindow(QtWidgets.QMainWindow):
         self.select_fitting_algorithm(self.settings.fitting_algorithm)
         self.ui.use_errors_checkbox.setChecked(self.settings.useerrors)
         self.settransformoption(self.settings.transformdata)
+
+    def compensate_older_versions(self):
+        """
+        Amends the internal state of the program to add attributes that may
+        be missing in experiment files that were saved in earlier versions of
+        the GUI.
+        """
+        # add interfaces attribute to all Components (added in v0.1.8)
+        # another way of doing it would be to use
+        # `self.__dict__.get('_interfaces', None)` in the interfaces property,
+        # but that is slower.
+        for do in self.treeModel.datastore:
+            model = do.model
+            s = model.structure
+            for component in s:
+                if not hasattr(component, '_interfaces'):
+                    component._interfaces = None
 
     def apply_settings_to_params(self, params):
         for key in self.settings.__dict__:


### PR DESCRIPTION
v0.1.8 will add the interfaces attribute to all Components. However, the attribute will be missing in mtft experiment files saved with previous versions. When those experiments are loaded a crash will result because the unpickled Components won't have the attribute. This PR adds the attribute to all the loaded Components if the object doesn't already possess it.