### PR TITLE
MAINT: use C++11 std::thread for _creflect

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -161,3 +161,6 @@ Details of changes made to refnx
 - Enabled parallel calculation of reflectivity using OpenMP. Tests show that
   it should be ~20% faster than the previous calculation in C.
 - tqdm progress bar for ptemcee sampling (if tqdm is installed).
+- Cleaned up the _creflect module. Threaded reflectivity calculation in that
+  extension now uses std::thread instead of pthreads (POSIX) or WinAPI
+  (windows).

--- a/setup.py
+++ b/setup.py
@@ -222,10 +222,7 @@ def setup_package():
                          'src/refcalc.cpp'],
                 include_dirs=[numpy_include],
                 language='c++',
-                extra_compile_args=[],
-                extra_link_args=['-lpthread']
-                # libraries=
-                # extra_compile_args = "...".split(),
+                extra_compile_args=['-std=c++11'],
             )
             ext_modules.append(_creflect)
 

--- a/src/refcalc.cpp
+++ b/src/refcalc.cpp
@@ -44,20 +44,9 @@ However, the following remains the fastest calculation  so far.
 #include <stdlib.h>
 #include <string.h>
 #include <cstdio>
+#include <thread>
+#include <vector>
 
-#ifdef _WIN32
-    #include <windows.h>
-    #include <process.h>
-#endif
-#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
-    #include <unistd.h>
-    #include <pthread.h>
-    #define HAVE_PTHREAD_H
-#endif
-
-//#ifdef _OPENMP
-//   #include <omp.h>
-//#endif
 
 #define NUM_CPUS 4
 #define PI 3.14159265358979323846
@@ -131,12 +120,7 @@ void AbelesCalc_ImagAll(int numcoefs,
 
         int nlayers = (int) coefP[0];
 
-        try{
-//		    // 2D array to hold wavevectors for each point, kn[npoints][nlayers + 2]
-//		    kn_all = (MyComplex **) malloc2d(npoints, nlayers + 2, sizeof(MyComplex));
-//		    if(kn_all == NULL)
-//		        goto done;
-
+        try {
             SLD = new complex<double>[nlayers + 2];
             thickness = new complex<double>[nlayers];
             rough_sqr = new double[nlayers + 1];
@@ -161,12 +145,6 @@ void AbelesCalc_ImagAll(int numcoefs,
         SLD[0] = complex<double>(0, 0);
         SLD[nlayers + 1] = 4e-6 * PI * (sub - super);
         rough_sqr[nlayers] = -2 * coefP[7] * coefP[7];
-
-// if you have omp.h, then can do the calculation in parallel.
-//#ifdef _OPENMP
-//        omp_set_num_threads(workers);
-//        #pragma omp parallel for shared(kn_all) private(j, num, den, answer, qq2, MRtotal, MI, temp2)
-//#endif
 
         for (j = 0; j < npoints; j++) {
             complex<double> beta, rj;
@@ -223,33 +201,6 @@ void AbelesCalc_ImagAll(int numcoefs,
             delete[] rough_sqr;
     }
 
-    typedef struct{
-        // a double array containing the model coefficients
-        const double *coefP;
-        // number of coefficients
-        int numcoefs;
-        // number of Q points we have to calculate
-        int npoints;
-        // the Reflectivity values to return
-        double *yP;
-        // the Q values to do the calculation for.
-        const double *xP;
-    }  pointCalcParm;
-
-/* pthread version */
-#ifdef HAVE_PTHREAD_H
-
-    void *ThreadWorker(void *arg){
-        pointCalcParm *p = (pointCalcParm *) arg;
-        AbelesCalc_ImagAll(p->numcoefs,
-                           p->coefP,
-                           p->npoints,
-                           p->yP,
-                           p->xP,
-                           0);
-        pthread_exit((void*)0);
-        return NULL;
-    }
 
     void AbelesCalc_Imag(int numcoefs,
                           const double *coefP,
@@ -258,26 +209,13 @@ void AbelesCalc_ImagAll(int numcoefs,
                              const double *xP,
                               int workers){
 
-        pthread_t *threads = NULL;
-        pointCalcParm *arg = NULL;
+        std::vector<std::thread> threads;
 
-        int threadsToCreate = workers - 1;
         int pointsEachThread, pointsRemaining, pointsConsumed;
 
-        // create threads for the calculation
-        threads = (pthread_t *) malloc((threadsToCreate) * sizeof(pthread_t));
-        if(!threads && workers > 1)
-            goto done;
-
-        // create arguments to be supplied to each of the threads
-        arg = (pointCalcParm *) malloc(sizeof(pointCalcParm)
-                                       * (threadsToCreate));
-        if(!arg && workers > 1)
-            goto done;
-
         // need to calculated how many points are given to each thread.
-        if(threadsToCreate > 0){
-            pointsEachThread = floorl(npoints / (threadsToCreate + 1));
+        if(workers > 0){
+            pointsEachThread = floorl(npoints / workers);
         } else {
             pointsEachThread = npoints;
         }
@@ -285,131 +223,33 @@ void AbelesCalc_ImagAll(int numcoefs,
         pointsRemaining = npoints;
         pointsConsumed = 0;
 
-        // if you have two CPU's, only create one extra thread because the main
-        // thread does half the work
-        for (int ii = 0; ii < threadsToCreate ; ii++){
-            arg[ii].coefP = coefP;
-            arg[ii].numcoefs = numcoefs;
-
-            arg[ii].npoints = pointsEachThread;
-
-            //the following two lines specify where the Q values and R values
-            //i.e. an offset of the original array.
-            arg[ii].xP = xP + pointsConsumed;
-            arg[ii].yP = yP + pointsConsumed;
-
-            pthread_create(&threads[ii], NULL, ThreadWorker,
-                           (void *)(arg + ii));
-            pointsRemaining -= pointsEachThread;
-            pointsConsumed += pointsEachThread;
-        }
-        // do the last points in the main thread.
-        AbelesCalc_ImagAll(numcoefs, coefP, pointsRemaining, yP + pointsConsumed, xP + pointsConsumed, 0);
-
-        for (int ii = 0; ii < threadsToCreate ; ii++)
-            pthread_join(threads[ii], NULL);
-
-    done:
-        if(threads)
-            free(threads);
-        if(arg)
-            free(arg);
-    }
-#endif
-
-#ifdef _WIN32
-    unsigned int __stdcall ThreadWorker(void *arg){
-            pointCalcParm *p = (pointCalcParm *) arg;
-            AbelesCalc_ImagAll(p->numcoefs,
-                               p->coefP,
-                               p->npoints,
-                               p->yP,
-                               p->xP,
-                               0);
-            return 0;
-    }
-
-    void AbelesCalc_Imag(int numcoefs,
-                          const double *coefP,
-                           int npoints,
-                            double *yP,
-                             const double *xP,
-                              int workers){
-
-        uintptr_t *threads = NULL;
-        pointCalcParm *arg = NULL;
-
-        int threadsToCreate = workers - 1;
-        int pointsEachThread, pointsRemaining, pointsConsumed;
-
-        // create threads for the calculation
-        threads = (uintptr_t *) malloc((threadsToCreate) * sizeof(uintptr_t));
-        if(!threads && workers > 1)
-            goto done;
-
-        // create arguments to be supplied to each of the threads
-        arg = (pointCalcParm *) malloc(sizeof(pointCalcParm)
-                                           * (threadsToCreate));
-        if(!arg && workers > 1)
-            goto done;
-
-        // need to calculated how many points are given to each thread.
-        if(threadsToCreate > 0){
-            pointsEachThread = (int) floor((double) npoints / ((double) threadsToCreate + 1));
-        } else {
-            pointsEachThread = npoints;
+        for (int ii = 0; ii < workers; ii++){
+            if(ii < workers - 1){
+                threads.emplace_back(std::thread(AbelesCalc_ImagAll,
+                                                 numcoefs,
+                                                 coefP,
+                                                 pointsEachThread,
+                                                 yP + pointsConsumed,
+                                                 xP + pointsConsumed,
+                                                 0));
+                pointsRemaining -= pointsEachThread;
+                pointsConsumed += pointsEachThread;
+            } else {
+                threads.emplace_back(std::thread(AbelesCalc_ImagAll,
+                                                 numcoefs,
+                                                 coefP,
+                                                 pointsRemaining,
+                                                 yP + pointsConsumed,
+                                                 xP + pointsConsumed,
+                                                 0));
+                pointsRemaining -= pointsRemaining;
+                pointsConsumed += pointsRemaining;
+            }
         }
 
-        pointsRemaining = npoints;
-        pointsConsumed = 0;
-
-        for( int ii=0; ii<threadsToCreate; ii++ )
-        {
-            // if you have two CPU's, only create one extra thread because the main
-            // thread does half the work
-            arg[ii].coefP = coefP;
-            arg[ii].numcoefs = numcoefs;
-
-            arg[ii].npoints = pointsEachThread;
-
-            //the following two lines specify where the Q values and R values
-            //i.e. an offset of the original array.
-            arg[ii].xP = xP + pointsConsumed;
-            arg[ii].yP = yP + pointsConsumed;
-
-            threads[ii] = _beginthreadex(
-                                         NULL,                   // default security attributes
-                                         0,                      // use default stack size
-                                         ThreadWorker,           // thread function name
-                                         (void*) &arg[ii],        // argument to thread function
-                                         0,                      // use default creation flags
-                                         NULL);                  // returns the thread identifier
-
-            if(threads[ii] == 0)
-                goto done;
-
-            pointsRemaining -= pointsEachThread;
-            pointsConsumed += pointsEachThread;
-        }
-        // do the last points in the main thread.
-        AbelesCalc_ImagAll(numcoefs, coefP, pointsRemaining, yP + pointsConsumed, xP + pointsConsumed, 0);
-
-        // Wait until all threads have terminated.
-        WaitForMultipleObjects(threadsToCreate, (HANDLE *)threads, TRUE, INFINITE);
-
-        done:
-            if(threads)
-                // Close all thread handles and free memory allocations.
-                for(int ii=0; ii<threadsToCreate; ii++){
-                    if(threads[ii])
-                        CloseHandle((HANDLE) threads[ii]);
-                }
-
-                free(threads);
-            if(arg)
-                free(arg);
+        // synchronise threads
+        for (auto& th : threads) th.join();
     }
-#endif
 
 
 /*
@@ -425,15 +265,7 @@ void reflectMT(int numcoefs,
 choose between the mode of calculation, depending on whether pthreads or omp.h
 is present for parallelisation.
 */
-#if defined HAVE_PTHREAD_H
     AbelesCalc_Imag(numcoefs, coefP, npoints, yP, xP, threads);
-//#elif defined _OPENMP
-//    AbelesCalc_ImagAll(numcoefs, coefP, npoints, yP, xP, threads);
-#elif defined _WIN32
-    AbelesCalc_Imag(numcoefs, coefP, npoints, yP, xP, threads);
-#else
-    AbelesCalc_ImagAll(numcoefs, coefP, npoints, yP, xP, 0);
-#endif
 }
 
 /*


### PR DESCRIPTION
Reflectivity calculation in refcalc.cpp is much cleaner when using c++11 std::thread compared to a mix of pthreads and windows threading.