### PR TITLE
Bound from rvcontinuous

### DIFF
--- a/refnx/analysis/bounds.py
+++ b/refnx/analysis/bounds.py
@@ -94,11 +94,13 @@ class PDF(Bounds):
     (-11.043938533204672, -11.043938533204672)
 
     """
-    def __init__(self, rv, seed=None):
+    def __init__(self, rv, bounds=[-np.inf, np.inf], seed=None):
         super(PDF, self).__init__(seed=seed)
         # we'll accept any object so long as it has logpdf and rvs methods
         if hasattr(rv, 'logpdf') and hasattr(rv, 'rvs'):
             self.rv = rv
+            self.lb = bounds[0]
+            self.ub = bounds[1]
         else:
             raise ValueError("You must initialise PDF with an object that has"
                              " logpdf and rvs methods")

--- a/refnx/analysis/curvefitter.py
+++ b/refnx/analysis/curvefitter.py
@@ -9,6 +9,7 @@ import numpy as np
 from scipy._lib._util import check_random_state
 from scipy.optimize import minimize, differential_evolution, least_squares
 import scipy.optimize as sciopt
+import scipy.stats as scistat
 
 from refnx.analysis import Objective, Interval, PDF, is_parameter
 from refnx._lib import (unique as f_unique, MapWrapper,
@@ -907,6 +908,12 @@ def bounds_list(parameters):
                 isinstance(param.bounds, Interval)):
             bnd = param.bounds
             bounds.append((bnd.lb, bnd.ub))
+        elif (hasattr(param, 'bounds') and isinstance(param.bounds, PDF) and
+              isinstance(param.bounds.rv,
+                         (scistat.rv_continuous,
+                          scistat._distn_infrastructure.rv_frozen)) and
+              np.isfinite([param.bounds.rv.a, param.bounds.rv.b]).all()):
+            bounds.append((param.bounds.rv.a, param.bounds.rv.b))
         elif (hasattr(param, 'bounds') and isinstance(param.bounds, PDF) and
               hasattr(param.bounds.rv, 'ppf')):
             bounds.append(param.bounds.rv.ppf([0.005, 0.995]))

--- a/refnx/analysis/curvefitter.py
+++ b/refnx/analysis/curvefitter.py
@@ -909,11 +909,8 @@ def bounds_list(parameters):
             bnd = param.bounds
             bounds.append((bnd.lb, bnd.ub))
         elif (hasattr(param, 'bounds') and isinstance(param.bounds, PDF) and
-              isinstance(param.bounds.rv,
-                         (scistat.rv_continuous,
-                          scistat._distn_infrastructure.rv_frozen)) and
-              np.isfinite([param.bounds.rv.a, param.bounds.rv.b]).all()):
-            bounds.append((param.bounds.rv.a, param.bounds.rv.b))
+              np.isfinite([param.bounds.lb, param.bounds.ub]).all()):
+            bounds.append((param.bounds.lb, param.bounds.ub))
         elif (hasattr(param, 'bounds') and isinstance(param.bounds, PDF) and
               hasattr(param.bounds.rv, 'ppf')):
             bounds.append(param.bounds.rv.ppf([0.005, 0.995]))

--- a/refnx/analysis/test/test_curvefitter.py
+++ b/refnx/analysis/test/test_curvefitter.py
@@ -79,6 +79,9 @@ class TestCurveFitter(object):
         self.p[0].bounds = PDF(norm(0, 1))
         assert_allclose(bounds_list(self.p),
                         [norm(0, 1).ppf([0.005, 0.995]), (-100, 100)])
+        self.p[0].bounds.rv.a = 0.2
+        self.p[0].bounds.rv.b = 0.8
+        assert_allclose(bounds_list(self.p), [[0.2, 0.8], (-100, 100)])
 
     def test_constraints(self):
         # constraints should work during fitting

--- a/refnx/analysis/test/test_curvefitter.py
+++ b/refnx/analysis/test/test_curvefitter.py
@@ -3,7 +3,7 @@ import pickle
 
 import numpy as np
 import scipy.optimize as sciopt
-from scipy.stats import norm
+from scipy.stats import norm, truncnorm
 
 import pytest
 from numpy.testing import (assert_, assert_almost_equal, assert_equal,
@@ -79,9 +79,8 @@ class TestCurveFitter(object):
         self.p[0].bounds = PDF(norm(0, 1))
         assert_allclose(bounds_list(self.p),
                         [norm(0, 1).ppf([0.005, 0.995]), (-100, 100)])
-        self.p[0].bounds.rv.a = 0.2
-        self.p[0].bounds.rv.b = 0.8
-        assert_allclose(bounds_list(self.p), [[0.2, 0.8], (-100, 100)])
+        self.p[0].bounds = PDF(truncnorm(0.2, 0.8, 1, 1), bounds=[0.2, 1.2])
+        assert_allclose(bounds_list(self.p), [(0.2, 1.2), (-100, 100)])
 
     def test_constraints(self):
         # constraints should work during fitting


### PR DESCRIPTION
If `a` and `b` are defined for a `scipy.stats.rv_continuous` object use these as bounds

https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rv_continuous.html