### PR TITLE
DOC: expand dependency list

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -35,7 +35,7 @@ Creating a conda environment
 
     ::
 
-     conda create -n refnx python=3.7 numpy scipy cython pandas h5py xlrd pytest
+     conda create -n refnx python=3.7 numpy scipy cython pandas h5py xlrd pytest pyqt matplotlib
 
 2. Activate the environment that we're going to be working in:
 
@@ -51,7 +51,7 @@ Creating a conda environment
 
     ::
 
-     pip install uncertainties ptemcee
+     pip install uncertainties ptemcee periodictable
 
 Installing from source
 =======================


### PR DESCRIPTION
A user reports that they couldn't start the refnx gui with the suggested way of setting up the conda environment (in the installation instructions documentation).

This PR adds a few packages to the suggested setup that will allow the refnx gui to start from the command line. These packages are not required if the GUI isn't being used, but it probably makes sense to have them there. @joscooper