### PR TITLE
ENH: align SLD plots at a specific interface

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -172,3 +172,5 @@ Details of changes made to refnx
 - event mode data reduction sped up by an order of magnitude
 - Added neutron transmission calculator (if periodictable is present)
 - event file reader can now read any ANSTO packedbin file (reduction).
+- Align SLD plots around a specific interface in a slab representation. Useful
+  if plotting many samples at the same time.


### PR DESCRIPTION
Useful when plotting lots of MCMC samples at the same time.