### PR TITLE
ENH: add MaterialSLD object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,12 @@ matrix:
 
 
 addons:
+    homebrew:
+      packages:
+        - libomp
     apt:
-        packages:
-            - libhdf5-serial-dev
+      packages:
+        - libhdf5-serial-dev
 
 services:
   - xvfb
@@ -59,7 +62,6 @@ before_install:
     # enable OpenMP support for Apple-clang
     - |
       if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        brew install libomp
         export CC=/usr/bin/clang
         export CXX=/usr/bin/clang++
         export CXXFLAGS="$CXXFLAGS -Xpreprocessor -fopenmp"

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -174,3 +174,6 @@ Details of changes made to refnx
 - event file reader can now read any ANSTO packedbin file (reduction).
 - Align SLD plots around a specific interface in a slab representation. Useful
   if plotting many samples at the same time.
+- Add MaterialSLD object that is constructed from a chemical formula and mass
+  density. This enables the use of specific materials to describe layers, e.g.
+  MaterialSLD('SiO2', density=2.2).

--- a/refnx/reflect/__init__.py
+++ b/refnx/reflect/__init__.py
@@ -3,7 +3,7 @@ import os
 from refnx.reflect.reflect_model import (ReflectModel, reflectivity,
                                          MixedReflectModel)
 from refnx.reflect.structure import (Structure, SLD, Slab, Component,
-                                     sld_profile, Stack)
+                                     sld_profile, Stack, MaterialSLD)
 from refnx.reflect.interface import (Erf, Interface, Linear, Exponential,
                                      Tanh, Sinusoidal, Step)
 from refnx.reflect.spline import Spline

--- a/refnx/reflect/structure.py
+++ b/refnx/reflect/structure.py
@@ -807,7 +807,7 @@ class MaterialSLD(SLD):
     probe : {'x-ray', 'neutron'}, optional
         Are you using neutrons or X-rays?
     wavelength : float, optional
-        wavelength of radiation
+        wavelength of radiation (Angstrom)
     name : str, optional
         Name of material
 

--- a/refnx/reflect/structure.py
+++ b/refnx/reflect/structure.py
@@ -823,7 +823,7 @@ class MaterialSLD(SLD):
         self._real = None
         self._imag = None
 
-        self._formula = pt.formula(formula, density=density)
+        self.__formula = pt.formula(formula)
         self._compound = formula
         self.density = possibly_create_parameter(density, name='density')
         self._parameters = Parameters(name=name)
@@ -838,24 +838,27 @@ class MaterialSLD(SLD):
 
     @property
     def formula(self):
-        return self._formula
+        return self._compound
 
     @formula.setter
     def formula(self, formula):
         import periodictable as pt
-        self._formula = pt.formula(formula, self.density.value)
+        self.__formula = pt.formula(formula)
         self._compound = formula
 
     @property
     def real(self):
-        return self._formula.neutron_sld(wavelength=1.8)[0]
+        sldc = complex(self)
+        return sldc.real
 
     @property
     def imag(self):
-        return self._formula.neutron_sld(wavelength=1.8)[1]
+        sldc = complex(self)
+        return sldc.imag
 
     def __complex__(self):
-        sldc = self._formula.neutron_sld(wavelength=1.8)
+        import periodictable as pt
+        sldc = pt.neutron_sld(self.__formula, density=self.density.value)
         return complex(sldc[0], sldc[1])
 
 

--- a/refnx/reflect/test/test_structure.py
+++ b/refnx/reflect/test/test_structure.py
@@ -170,6 +170,16 @@ class TestStructure(object):
 
     def test_materialsld(self):
         p = MaterialSLD('SiO2', density=2.2, name='silica')
+        assert_allclose(float(p.real), 3.4752690258246504)
+        assert_allclose(float(p.imag), 1.0508799522721932e-05)
+
+        assert p.formula == 'SiO2'
+
+        # the density value should change the SLD
+        p.density.value = 4.4
+        assert_allclose(float(p.real), 3.4752690258246504 * 2)
+        assert_allclose(float(p.imag), 1.0508799522721932e-05 * 2)
+
         slab = p(10, 3)
         assert isinstance(slab, Slab)
         slab = Slab(10, p, 3)

--- a/refnx/reflect/test/test_structure.py
+++ b/refnx/reflect/test/test_structure.py
@@ -165,17 +165,30 @@ class TestStructure(object):
         assert_allclose(float(p.imag), 1.0508799522721932e-05)
         print(repr(p))
         q = eval(repr(p))
-        assert_allclose(float(p.real), 3.4752690258246504)
-        assert_allclose(float(p.imag), 1.0508799522721932e-05)
+        assert_allclose(float(q.real), 3.4752690258246504)
+        assert_allclose(float(q.imag), 1.0508799522721932e-05)
 
     def test_materialsld(self):
         p = MaterialSLD('SiO2', density=2.2, name='silica')
+        sldc = complex(p)
         assert_allclose(float(p.real), 3.4752690258246504)
         assert_allclose(float(p.imag), 1.0508799522721932e-05)
+        assert_allclose(sldc.real, 3.4752690258246504)
+        assert_allclose(sldc.imag, 1.0508799522721932e-05)
+        assert p.probe == 'neutron'
 
+        # is X-ray SLD correct?
+        p.wavelength = 1.54
+        p.probe = 'x-ray'
+        sldc = complex(p)
+        assert_allclose(sldc.real, 18.864796064009866)
+        assert_allclose(sldc.imag, 0.2436013463223236)
+
+        assert len(p.parameters) == 1
         assert p.formula == 'SiO2'
 
         # the density value should change the SLD
+        p.probe = 'neutron'
         p.density.value = 4.4
         assert_allclose(float(p.real), 3.4752690258246504 * 2)
         assert_allclose(float(p.imag), 1.0508799522721932e-05 * 2)

--- a/refnx/reflect/test/test_structure.py
+++ b/refnx/reflect/test/test_structure.py
@@ -6,7 +6,7 @@ from numpy.testing import (assert_almost_equal, assert_equal, assert_,
 from scipy.stats import cauchy
 from refnx._lib import flatten
 from refnx.reflect import (SLD, Structure, Spline, Slab, Stack, Erf,
-                           Linear, Exponential, Interface)
+                           Linear, Exponential, Interface, MaterialSLD)
 from refnx.reflect.structure import _profile_slicer
 from refnx.analysis import Parameter, Interval, Parameters
 
@@ -158,6 +158,22 @@ class TestStructure(object):
         q = eval(repr(p))
         assert_equal(float(q.real), 5)
         assert_equal(float(q.imag), 1)
+
+    def test_repr_materialsld(self):
+        p = MaterialSLD('SiO2', density=2.2, name='silica')
+        assert_allclose(float(p.real), 3.4752690258246504)
+        assert_allclose(float(p.imag), 1.0508799522721932e-05)
+        print(repr(p))
+        q = eval(repr(p))
+        assert_allclose(float(p.real), 3.4752690258246504)
+        assert_allclose(float(p.imag), 1.0508799522721932e-05)
+
+    def test_materialsld(self):
+        p = MaterialSLD('SiO2', density=2.2, name='silica')
+        slab = p(10, 3)
+        assert isinstance(slab, Slab)
+        slab = Slab(10, p, 3)
+        assert isinstance(slab, Slab)
 
     def test_repr_slab(self):
         p = SLD(5 + 1j)

--- a/refnx/reflect/test/test_structure.py
+++ b/refnx/reflect/test/test_structure.py
@@ -180,10 +180,21 @@ class TestStructure(object):
         assert_allclose(float(p.real), 3.4752690258246504 * 2)
         assert_allclose(float(p.imag), 1.0508799522721932e-05 * 2)
 
+        # should be able to make a Slab from MaterialSLD
         slab = p(10, 3)
         assert isinstance(slab, Slab)
         slab = Slab(10, p, 3)
         assert isinstance(slab, Slab)
+
+        # make a full structure and check that the reflectivity calc works
+        air = SLD(0)
+        sio2 = MaterialSLD('SiO2', density=2.2)
+        si = MaterialSLD('Si', density=2.33)
+        s = air | sio2(10, 3) | si(0, 3)
+        s.reflectivity(np.linspace(0.005, 0.3, 100))
+
+        p = s.parameters
+        assert len(list(flatten(p))) == 5 + 4 + 4
 
     def test_repr_slab(self):
         p = SLD(5 + 1j)

--- a/src/_cevent.pyx
+++ b/src/_cevent.pyx
@@ -217,10 +217,11 @@ cpdef unpack_buffer(buffer,
     written to the header and need not be specified, unless some alternate
     scale is needed.
     """
-    scale_microsec = 1 / hdr_base.clock_scale
     if not hdr_base.clock_scale:
         # old eventfile format did not have clock_scale...
         scale_microsec = 1 / def_clock_scale
+    else:
+        scale_microsec = 1 / hdr_base.clock_scale
 
     # the initial time is not set correctly so wait until primary and auxillary
     # time have been reset before sending events


### PR DESCRIPTION
Create a scattering object using a chemical formula and mass density:

```
sio2 = MaterialSLD('SiO2', density=2.2)
```

`MaterialSLD` extends SLD, so *should* be able to be used in most places where an `SLD` is used.