### PR TITLE
TST: travis test from sdist fixes #381

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ script:
     - export REQUIRE_C=1
     - export MPLBACKEND=agg
     # put cwd in the top of the directory stack
-    - pushd
+    - pushd .
     # install and test from the sdist
     - python setup.py sdist
     - cd dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,8 +75,14 @@ script:
     # definitely want to test the _creflect module on travis.
     - export REQUIRE_C=1
     - export MPLBACKEND=agg
-    - pip install .
-    - pytest
+    # put cwd in the top of the directory stack
+    - pushd
+    # install and test from the sdist
+    - python setup.py sdist
+    - pip install *.tar.gz
+    - python -c 'import refnx;refnx.test()'
+    # restore the working directory to the root refnx directory
+    - popd
     - sphinx-build -b html doc doc/html
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ script:
     - pushd
     # install and test from the sdist
     - python setup.py sdist
+    - cd dist
     - pip install *.tar.gz
     - python -c 'import refnx;refnx.test()'
     # restore the working directory to the root refnx directory


### PR DESCRIPTION
This PR amends the travis tests to create an sdist, install from that sdist, then run the tests. This modification should catch issues like #381.