### PR TITLE
ENH: choose fastest smearing type

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -203,3 +203,6 @@ Details of changes made to refnx
   a bug in MixedSlab.
 - Don't require numpy be installed before setup.py can run.
 - Speed up reflectivity calculation if there is solvation.
+- reflect.choose_dq_type for finding out fastest mode of resolution smearing.
+- User can now select resolution smearing approach in ReflectModel. Choosing
+  between 'pointwise' or 'constant'.

--- a/refnx/reflect/__init__.py
+++ b/refnx/reflect/__init__.py
@@ -1,7 +1,8 @@
 import os
 
 from refnx.reflect.reflect_model import (ReflectModel, reflectivity,
-                                         MixedReflectModel, FresnelTransform)
+                                         MixedReflectModel, FresnelTransform,
+                                         choose_dq_type)
 from refnx.reflect.structure import (Structure, SLD, Slab, Component,
                                      sld_profile, Stack, MaterialSLD,
                                      MixedSlab)

--- a/refnx/reflect/reflect_model.py
+++ b/refnx/reflect/reflect_model.py
@@ -1074,7 +1074,8 @@ def choose_dq_type(objective):
     """
     # choose which resolution smearing approach to use
     if (objective.data.x_err is None or
-            not isinstance(objective.model, (ReflectModel, MixedReflectModel))):
+            not isinstance(objective.model,
+                           (ReflectModel, MixedReflectModel))):
         return 'pointwise'
 
     original_method = objective.model.dq_type

--- a/refnx/reflect/test/test_reflect.py
+++ b/refnx/reflect/test/test_reflect.py
@@ -685,12 +685,12 @@ class TestReflect(object):
 
         # check that the comparison worked
         const_time = time.time()
-        objective.generative()
+        for i in range(1000): objective.generative()
         const_time = time.time() - const_time
 
         model.dq_type = 'pointwise'
         point_time = time.time()
-        objective.generative()
+        for i in range(1000): objective.generative()
         point_time = time.time() - point_time
 
         if fastest_method == 'pointwise':

--- a/refnx/reflect/test/test_reflect.py
+++ b/refnx/reflect/test/test_reflect.py
@@ -685,12 +685,14 @@ class TestReflect(object):
 
         # check that the comparison worked
         const_time = time.time()
-        for i in range(1000): objective.generative()
+        for i in range(1000):
+            objective.generative()
         const_time = time.time() - const_time
 
         model.dq_type = 'pointwise'
         point_time = time.time()
-        for i in range(1000): objective.generative()
+        for i in range(1000):
+            objective.generative()
         point_time = time.time() - point_time
 
         if fastest_method == 'pointwise':


### PR DESCRIPTION
- reflect.choose_dq_type for finding out fastest mode of resolution smearing.
- User can now select resolution smearing approach in ReflectModel. Choosing
  between 'pointwise' or 'constant'.