### PR TITLE
ENH: speed up (un)pickling of Bounds

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -208,3 +208,5 @@ Details of changes made to refnx
   between 'pointwise' or 'constant'.
 - Add progress bar for Curvefitter.fit() (requires tqdm being installed).
 - A few micro-optimisations.
+- Optimized pickling/unpickling of Bounds instances. This can lead to a huge
+  performance increase (~ 40%) when doing parallel sampling.

--- a/refnx/analysis/bounds.py
+++ b/refnx/analysis/bounds.py
@@ -1,3 +1,4 @@
+import math
 from scipy.stats import rv_continuous, uniform
 from scipy.stats._distn_infrastructure import rv_frozen
 from scipy._lib._util import check_random_state
@@ -213,10 +214,10 @@ class Interval(Bounds):
         self._ub = max(lb, ub)
         self._closed_bounds = False
 
-        if np.isnan([self._lb, self._ub]).any():
+        if math.isnan(self._lb) or math.isnan(self._ub):
             raise ValueError("Can't set Interval with NaN")
 
-        if np.isfinite([self._lb, self._ub]).all():
+        if math.isfinite(self._lb) and math.isfinite(self._ub):
             self._closed_bounds = True
             if self._lb == self._ub:
                 self._logprob = 0.

--- a/refnx/analysis/bounds.py
+++ b/refnx/analysis/bounds.py
@@ -339,8 +339,8 @@ class Interval(Bounds):
 
     def rvs(self, size=1, random_state=None):
         if self._closed_bounds:
-            gen = check_random_state(random_state)
-            return gen.uniform(self._lb, self._ub, size=size)
+            return uniform.rvs(self._lb, self._ub - self._lb, size=size,
+                               random_state=random_state)
         else:
             raise RuntimeError("Can't ask for a random variate from a"
                                " semi-closed interval")

--- a/refnx/analysis/test/test_bounds.py
+++ b/refnx/analysis/test/test_bounds.py
@@ -83,7 +83,7 @@ class TestBounds(object):
         assert_equal(pdf.logp(0), norm.logpdf(0))
 
         # examine dist with finite support
-        pdf = PDF(truncnorm(-1, 1), seed=1)
+        pdf = PDF(truncnorm(-1, 1))
         assert_equal(pdf.logp(-2), -np.inf)
         assert_equal(pdf.logp(-0.5), truncnorm.logpdf(-0.5, -1, 1))
 


### PR DESCRIPTION
@igresh, big performance increase when sampling from this (depending on system).

Fast pickling/unpickling speed is essential for good `multiprocessing` performance. We want all the processor time spent in calculating reflectivities, not being used in pickling overhead. This PR significantly reduces the pickling overhead.
For the system I examined (2 slabs, 3 contrasts, 100 data points per contrast) I went from ~2.3 minutes down to 1.5 minutes for a certain sampling.
The improvement will be less for systems that spend longer calculating reflectivities (such as brushes)