### PR TITLE
MAINT: enable pyopencl for reflectivity calculation

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: setup apt dependencies
       run: |
-        sudo apt-get update opencl-headers
+        sudo apt-get update
         sudo apt-get install xvfb qt5-default opencl-headers
     - name: Install dependencies
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,6 +19,10 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - name: setup apt dependencies
+      run: |
+        sudo apt-get update opencl-headers
+        sudo apt-get install xvfb qt5-default opencl-headers
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -31,10 +35,6 @@ jobs:
         pip install flake8
         # stop the build if there are Python syntax errors or undefined names
         flake8 --ignore=F401,W504 --count --show-source --statistics --exclude=refnx/_lib/emcee,refnx/reflect/_app/resources_rc.py refnx
-    - name: setup xvfb
-      run: |
-        sudo apt-get update
-        sudo apt-get install xvfb qt5-default
     - name: Test with pytest
       env:
         MPLBACKEND: agg

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,14 +22,14 @@ jobs:
     - name: setup apt dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install xvfb qt5-default opencl-headers
+        sudo apt-get install xvfb qt5-default opencl-headers ocl-icd-opencl-dev
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install numpy scipy h5py cython pandas xlrd flake8 pytest ipywidgets IPython matplotlib traitlets pyqt5
-        pip install uncertainties ptemcee corner tqdm pytest-qt periodictable pyopencl
+        python -m pip install wheel
+        python -m pip install numpy scipy h5py cython pandas xlrd flake8 pytest ipywidgets IPython matplotlib traitlets pyqt5
+        python -m pip install uncertainties ptemcee corner tqdm pytest-qt periodictable pyopencl
         pip install git+https://github.com/pymc-devs/pymc3
-        pip install .
     - name: Lint with flake8
       run: |
         pip install flake8
@@ -39,7 +39,8 @@ jobs:
       env:
         MPLBACKEND: agg
       run: |
-        pip install pytest
+        python -m pip install .
+        python -m pip install pytest
         # uses xvfb for GUI part of the test
         xvfb-run pytest
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install numpy scipy h5py cython pandas xlrd flake8 pytest ipywidgets IPython matplotlib traitlets pyqt5
-        pip install uncertainties ptemcee corner tqdm pytest-qt periodictable
+        pip install uncertainties ptemcee corner tqdm pytest-qt periodictable pyopencl
         pip install git+https://github.com/pymc-devs/pymc3
         pip install .
     - name: Lint with flake8
@@ -84,7 +84,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install numpy scipy h5py cython pandas xlrd pytest ipywidgets IPython matplotlib traitlets pyqt5
-        pip install uncertainties ptemcee corner tqdm pytest-qt periodictable wheel delocate
+        pip install uncertainties ptemcee corner tqdm pytest-qt periodictable wheel delocate pyopencl
         pip install git+https://github.com/pymc-devs/pymc3
 
     - name: Make wheel

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -229,3 +229,6 @@ Details of changes made to refnx
   C99 standard conformant compiler.
 - Document how to save a model.
 - macOS wheels (and CI testing) have the cyreflect openmp option activated.
+- An openCL reflectivity calculation backend is added that can use a GPU. It
+  is less accurate and slower than the C backend, but is included for
+  completeness.

--- a/refnx/reflect/_reflect.py
+++ b/refnx/reflect/_reflect.py
@@ -123,7 +123,9 @@ try:
             cl.enqueue_copy(queue, reflectivity, ref_g)
         return reflectivity
 
-except ImportError:
+except Exception:
+    # general catch-all because I don't know what other Exceptions will be
+    # raised
     pass
 
 

--- a/refnx/reflect/_reflect.py
+++ b/refnx/reflect/_reflect.py
@@ -23,8 +23,8 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THIS SOFTWARE.
 
 """
+import os.path
 import numpy as np
-
 
 # TINY = np.finfo(np.float64).tiny
 TINY = 1e-30
@@ -49,6 +49,82 @@ If TINY is made too small, then the C implementations start too suffer because
 the sqrt calculation takes too long. The C implementation is only just ahead of
 the python implementation!
 """
+
+try:
+    import pyopencl as cl
+    ctx = cl.create_some_context()
+
+    pth = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(pth, 'abeles_pyopencl.cl'), 'r') as f:
+        src = f.read()
+    prg = cl.Program(ctx, src).build()
+
+    def abeles_pyopencl(q, w, scale=1, bkg=0, threads=0):
+        """
+        Abeles matrix formalism for calculating reflectivity from a stratified
+        medium.
+        Uses pyopencl on a GPU to calculate reflectivity. The accuracy of this
+        function is not as good as the C and Python based versions.
+
+        Parameters
+        ----------
+        q: array_like
+            the q values required for the calculation.
+            Q = 4 * Pi / lambda * sin(omega).
+            Units = Angstrom**-1
+        layers: np.ndarray
+            coefficients required for the calculation, has shape (2 + N, 4),
+            where N is the number of layers
+            layers[0, 1] - SLD of fronting (/1e-6 Angstrom**-2)
+            layers[0, 2] - iSLD of fronting (/1e-6 Angstrom**-2)
+            layers[N, 0] - thickness of layer N
+            layers[N, 1] - SLD of layer N (/1e-6 Angstrom**-2)
+            layers[N, 2] - iSLD of layer N (/1e-6 Angstrom**-2)
+            layers[N, 3] - roughness between layer N-1/N
+            layers[-1, 1] - SLD of backing (/1e-6 Angstrom**-2)
+            layers[-1, 2] - iSLD of backing (/1e-6 Angstrom**-2)
+            layers[-1, 3] - roughness between backing and last layer
+        scale: float
+            Multiply all reflectivities by this value.
+        bkg: float
+            Linear background to be added to all reflectivities
+        threads: int, optional
+            <THIS OPTION IS CURRENTLY IGNORED>
+
+        Returns
+        -------
+        Reflectivity: np.ndarray
+            Calculated reflectivity values for each q value.
+        """
+        nlayers = len(w) - 2
+        coefs = np.empty((nlayers * 4 + 8))
+        coefs[0] = nlayers
+        coefs[1] = scale
+        coefs[2:4] = w[0, 1: 3]
+        coefs[4: 6] = w[-1, 1: 3]
+        coefs[6] = bkg
+        coefs[7] = w[-1, 3]
+        if nlayers:
+            coefs[8::4] = w[1:-1, 0]
+            coefs[9::4] = w[1:-1, 1]
+            coefs[10::4] = w[1:-1, 2]
+            coefs[11::4] = w[1:-1, 3]
+
+        mf = cl.mem_flags
+        with cl.CommandQueue(ctx) as queue:
+            q_g = cl.Buffer(ctx, mf.READ_ONLY | mf.USE_HOST_PTR, hostbuf=q)
+            coefs_g = cl.Buffer(ctx, mf.READ_ONLY | mf.USE_HOST_PTR,
+                                hostbuf=coefs)
+            ref_g = cl.Buffer(ctx, mf.WRITE_ONLY, q.nbytes)
+
+            prg.abeles(queue, q.shape, None, q_g, coefs_g, ref_g)
+
+            reflectivity = np.empty_like(q)
+            cl.enqueue_copy(queue, reflectivity, ref_g)
+        return reflectivity
+
+except ImportError:
+    pass
 
 
 def abeles(q, layers, scale=1., bkg=0, threads=0):

--- a/refnx/reflect/abeles_pyopencl.cl
+++ b/refnx/reflect/abeles_pyopencl.cl
@@ -1,0 +1,87 @@
+#define PYOPENCL_DEFINE_CDOUBLE
+#include <pyopencl-complex.h>
+
+__kernel void abeles(
+    __global const double *q_g, __global const double *coefs_g, __global double *ref_g)
+{
+    int gid = get_global_id(0);
+
+    cdouble_t q2, kn, k_next, rj, SLD, _t, beta, I;
+    cdouble_t mrtot00, mrtot01, mrtot10, mrtot11;
+    cdouble_t mi00, mi01, mi10, mi11, p0, p1;
+
+    int ii;
+    int nlayers;
+    double rough, M_4PI, thick;
+
+    M_4PI = 12.566370614359172;
+    nlayers = (int) coefs_g[0];
+
+    q2 = cdouble_fromreal(q_g[gid] * q_g[gid] / 4.);
+    kn = cdouble_fromreal(q_g[gid] / 2.);
+
+    mrtot00.real = 1.;
+    mrtot00.imag = 0.;
+    mrtot11.real = 1.;
+    mrtot00.imag = 0.;
+    I.real = 0.;
+    I.imag = 1.;
+
+    for(ii = 0 ; ii < nlayers + 1; ii += 1){
+        if(ii == nlayers){
+            // the backing medium
+            SLD.real = M_4PI * (coefs_g[4] - coefs_g[2]) * 1e-6;
+            SLD.imag = M_4PI * (fabs(coefs_g[5]) + 1e-30) * 1e-6;
+            rough = -2. * coefs_g[7] * coefs_g[7];
+        } else {
+            SLD.real = M_4PI * (coefs_g[4*ii + 9] - coefs_g[2]) * 1e-6;
+            SLD.imag = M_4PI * (fabs(coefs_g[4*ii + 10]) + 1e-30) * 1e-6;
+            rough = -2 * coefs_g[4*ii + 11] * coefs_g[4*ii + 11];
+        }
+
+        // wavevector in next layer
+        k_next = cdouble_sqrt(cdouble_sub(q2, SLD));
+
+        // reflectance coefficient
+        rj = cdouble_divide(cdouble_sub(kn, k_next), cdouble_add(kn, k_next));
+        _t = cdouble_exp(cdouble_mulr(cdouble_mul(kn, k_next), rough));
+        rj = cdouble_mul(rj, _t);
+
+        if(ii == 0){
+            mrtot01 = rj;
+            mrtot10 = rj;
+        } else {
+            thick = coefs_g[4*(ii - 1) + 8];
+            _t = cdouble_mul(kn, cdouble_mulr(I, thick));
+            beta = cdouble_exp(_t);
+
+            //this is the characteristic matrix of a layer
+            mi00 = beta;
+            mi11 = cdouble_rdivide(1., beta);
+            mi10 = cdouble_mul(rj, mi00);
+            mi01 = cdouble_mul(rj, mi11);
+
+            // matrix multiply
+            p0 = cdouble_add(cdouble_mul(mrtot00, mi00), cdouble_mul(mrtot10, mi01));
+            p1 = cdouble_add(cdouble_mul(mrtot00, mi10), cdouble_mul(mrtot10, mi11));
+            mrtot00 = p0;
+            mrtot10 = p1;
+
+            p0 = cdouble_add(cdouble_mul(mrtot01, mi00), cdouble_mul(mrtot11, mi01));
+            p1 = cdouble_add(cdouble_mul(mrtot01, mi10), cdouble_mul(mrtot11, mi11));
+
+            mrtot01 = p0;
+            mrtot11 = p1;
+
+        }
+        kn = k_next;
+
+    } // end of layer accumulation
+
+    _t = cdouble_divide(mrtot01, mrtot00);
+    _t = cdouble_mul(_t, cdouble_conj(_t));
+
+    ref_g[gid] = _t.real;
+    ref_g[gid] *= coefs_g[1];
+    ref_g[gid] += coefs_g[6];
+}

--- a/refnx/reflect/abeles_pyopencl.cl
+++ b/refnx/reflect/abeles_pyopencl.cl
@@ -1,3 +1,29 @@
+/*
+Calculates the specular (Neutron or X-ray) reflectivity from a stratified
+series of layers.
+
+The refnx code is distributed under the following license:
+
+Copyright (c) 2020 A. R. J. Nelson, ANSTO
+
+Permission to use and redistribute the source code or binary forms of this
+software and its documentation, with or without modification is hereby
+granted provided that the above notice of copyright, these terms of use,
+and the disclaimer of warranty below appear in the source code and
+documentation, and that none of the names of above institutions or
+authors appear in advertising or endorsement of works derived from this
+software without specific prior written permission from all parties.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THIS SOFTWARE.
+
+*/
+
 #define PYOPENCL_DEFINE_CDOUBLE
 #include <pyopencl-complex.h>
 

--- a/refnx/reflect/reflect_model.py
+++ b/refnx/reflect/reflect_model.py
@@ -71,17 +71,28 @@ def get_reflect_backend(backend='c'):
 
     Parameters
     ----------
-    backend: {'python', 'cython', 'c'}, str
+    backend: {'python', 'cython', 'c', 'pyopencl'}, str
         The module that calculates the reflectivity. Speed should go in the
-        order cython > c > python. If a particular method is not available the
-        function falls back: cython --> c --> python.
+        order: c > pyopencl > cython > python. If a particular method is not
+        available the function falls back: cython/pyopencl --> c --> python.
 
     Returns
     -------
     abeles: callable
         The callable that calculates the reflectivity
 
+    Notes
+    -----
+    The pyopencl implementation uses pyopencl on a GPU to calculate
+    reflectivity. It is not as accurate as the other options. 'c' is
+    preferred for most circumstances.
     """
+    if backend == 'pyopencl':
+        try:
+            from refnx.reflect._reflect import abeles_pyopencl
+            f = abeles_pyopencl
+        except ImportError:
+            return get_reflect_backend('c')
     if backend == 'cython':
         try:
             from refnx.reflect import _cyreflect as _cy

--- a/refnx/reflect/reflect_model.py
+++ b/refnx/reflect/reflect_model.py
@@ -93,18 +93,21 @@ def get_reflect_backend(backend='c'):
             from refnx.reflect._reflect import abeles_pyopencl
             f = abeles_pyopencl
         except ImportError:
+            warnings.warn("Can't use the pyopencl abeles backend")
             return get_reflect_backend('c')
     if backend == 'cython':
         try:
             from refnx.reflect import _cyreflect as _cy
             f = _cy.abeles
         except ImportError:
+            warnings.warn("Can't use the cython abeles backend")
             return get_reflect_backend('c')
     elif backend == 'c':
         try:
             from refnx.reflect import _creflect as _c
             f = _c.abeles
         except ImportError:
+            warnings.warn("Can't use the C abeles backend")
             return get_reflect_backend('python')
     elif backend == 'python':
         warnings.warn("Using the SLOW reflectivity calculation.")

--- a/refnx/reflect/reflect_model.py
+++ b/refnx/reflect/reflect_model.py
@@ -73,7 +73,7 @@ def get_reflect_backend(backend='c'):
     ----------
     backend: {'python', 'cython', 'c', 'pyopencl'}, str
         The module that calculates the reflectivity. Speed should go in the
-        order: c > pyopencl > cython > python. If a particular method is not
+        order: c > pyopencl / cython > python. If a particular method is not
         available the function falls back: cython/pyopencl --> c --> python.
 
     Returns
@@ -83,9 +83,10 @@ def get_reflect_backend(backend='c'):
 
     Notes
     -----
-    The pyopencl implementation uses pyopencl on a GPU to calculate
-    reflectivity. It is not as accurate as the other options. 'c' is
-    preferred for most circumstances.
+    'c' is preferred for most circumstances.
+    'pyopencl' uses a GPU to calculate reflectivity and requires that pyopencl
+    be installed. It is not as accurate as the other options. 'pyopencl' is
+    only included for completeness.
     """
     if backend == 'pyopencl':
         try:

--- a/refnx/reflect/test/test_reflect.py
+++ b/refnx/reflect/test/test_reflect.py
@@ -315,7 +315,7 @@ class TestReflect(object):
             calc2 = _reflect.abeles_pyopencl(self.qvals, layer2,
                                              scale=0.99, bkg=1e-8)
             assert_allclose(calc1, calc2, rtol=0.02)
-        except AttributeError:
+        except RuntimeError:
             pass
 
     def test_c_py_abeles_absorption(self):

--- a/refnx/reflect/test/test_reflect.py
+++ b/refnx/reflect/test/test_reflect.py
@@ -253,7 +253,7 @@ class TestReflect(object):
     """
 
     def test_compare_c_py_abeles0(self):
-        # test two layer system
+        # test one layer system
         # if not TEST_C_REFLECT:
         #     return
         layer0 = np.array([[0, 2.07, 0.01, 3],
@@ -303,6 +303,20 @@ class TestReflect(object):
         calc1 = _reflect.abeles(self.qvals, layer2, scale=0.99, bkg=1e-8)
         calc2 = _cyreflect.abeles(self.qvals, layer2, scale=0.99, bkg=1e-8)
         assert_almost_equal(calc1, calc2)
+
+    def test_compare_pyopencl_py_abeles2(self):
+        # test two layer system
+        layer2 = np.array([[0, 2.07, 0.01, 3],
+                           [10, 3.47, 0.01, 3],
+                           [100, 1.0, 0.01, 4],
+                           [0, 6.36, 0.1, 3]])
+        calc1 = _reflect.abeles(self.qvals, layer2, scale=0.99, bkg=1e-8)
+        try:
+            calc2 = _reflect.abeles_pyopencl(self.qvals, layer2,
+                                             scale=0.99, bkg=1e-8)
+            assert_allclose(calc1, calc2, rtol=0.02)
+        except AttributeError:
+            pass
 
     def test_c_py_abeles_absorption(self):
         # https://github.com/andyfaff/refl1d_analysis/tree/master/notebooks

--- a/refnx/reflect/test/test_reflect.py
+++ b/refnx/reflect/test/test_reflect.py
@@ -315,7 +315,7 @@ class TestReflect(object):
             calc2 = _reflect.abeles_pyopencl(self.qvals, layer2,
                                              scale=0.99, bkg=1e-8)
             assert_allclose(calc1, calc2, rtol=0.02)
-        except RuntimeError:
+        except AttributeError:
             pass
 
     def test_c_py_abeles_absorption(self):


### PR DESCRIPTION
This PR introduces the use of openCL to calculate the reflectivity. It's not as accurate, or as fast, as the C implementation (and is therefore not preferred). I'm putting it in the source code for completeness, it may come in handy in the future.
It is not used by default.