### PR TITLE
ENH: -ffast-math optimisation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -262,3 +262,4 @@ in 0.1.13.
 ------
 - Build more Linux wheels.
 - Vendored ptemcee (bleeding edge), so it's no longer necessary to install it.
+- Use -funsafe-math-optimizations for reflectivity calculation.

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -54,7 +54,6 @@
     "matrix": {
         "numpy": [],
         "Cython": [],
-        "pip+ptemcee": [],
     },
 
 

--- a/refnx/reflect/test/test_reflect.py
+++ b/refnx/reflect/test/test_reflect.py
@@ -339,14 +339,20 @@ class TestReflect(object):
         backends.remove("python")
         f_python = reflect_model.get_reflect_backend("python")
 
-        for i in range(25):
+        for i in range(40):
             w = get_w(i)
             canonical_r = f_python(x, w)
 
             for backend in backends:
                 with use_reflect_backend(backend) as abeles:
                     calc = abeles(x, w)
-                assert_almost_equal(calc, canonical_r)
+                try:
+                    assert_allclose(
+                        calc, canonical_r, atol=5.0e-15, rtol=8.0e-15
+                    )
+                except AssertionError as e:
+                    print(backend, i)
+                    raise e
 
     def test_use_reflectivity_backend(self):
         import refnx.reflect._creflect as _creflect

--- a/setup.py
+++ b/setup.py
@@ -361,7 +361,12 @@ def setup_package():
                 # and C code on other machines. The C code uses C99 complex
                 # arithmetic which is 10-20% faster.
                 # the CMPLX macro was only standardised in C11
-                extra_preargs.append('-std=c11')
+                extra_preargs.extend(
+                    ['-std=c11',
+                     '-funsafe-math-optimizations',
+                     '-ffinite-math-only',
+                    ]
+                )
                 f = ['src/refcalc.c']
 
             refcalc_obj = ccompiler.compile(f, extra_preargs=extra_preargs)

--- a/setup.py
+++ b/setup.py
@@ -368,7 +368,6 @@ def setup_package():
                     ]
                 )
                 f = ['src/refcalc.c']
-
             refcalc_obj = ccompiler.compile(f, extra_preargs=extra_preargs)
             print(refcalc_obj)
 

--- a/src/_creflect.pyx
+++ b/src/_creflect.pyx
@@ -91,6 +91,7 @@ cpdef cnp.ndarray abeles(cnp.ndarray x,
                          " shape (>2, 4)")
     if x.dtype != np.float64:
         raise ValueError("Q values for _creflect must be np.float64")
+
     cdef:
         int nlayers = w.shape[0] - 2
         int npoints = x.size


### PR DESCRIPTION
Try out `-ffast-math` optimisation, which speeds up reflectivity calculation. The main point of concern would be no signed zeros for complex maths arithmetic.