### PR TITLE
MAINT: logp_extra from logp to logl

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -270,3 +270,6 @@ in 0.1.13.
   Curvefitter.
 - implement `invcdf` method for Bounds objects. This will allow creation of
   prior transforms from [0, 1) to the original range specification.
+- BREAKING CHANGE: `objective.model.logp` and `Objective.logp_extra` are now
+  included in the log-likelihood (`Objective.logl`) instead of log-prior
+  (`Objective.logp`). This makes it easier to work with pymc3 and dynesty.

--- a/refnx/analysis/test/test_objective.py
+++ b/refnx/analysis/test/test_objective.py
@@ -234,11 +234,9 @@ class TestObjective(object):
         assert_equal(self.objective.residuals().size, residuals.size - 1)
 
     def test_logp_extra(self):
+        original_logl = self.objective.logl()
         self.objective.logp_extra = logp_extra
-
-        # repeat logp test
-        self.p[0].range(0, 10)
-        assert_almost_equal(self.objective.logp(), np.log(0.1) + 1)
+        assert_almost_equal(self.objective.logl(), original_logl + 1)
 
     def test_objective_pickle(self):
         # can you pickle the objective function?


### PR DESCRIPTION
BREAKING CHANGE: move `logp_extra` and `Objective.model.logp` from `Objective.logp` to `Objective.logl`. This is so the prior can be used more easily for pymc3 and dynesty.