### PR TITLE
Update bounds.py

### DIFF
--- a/refnx/analysis/bounds.py
+++ b/refnx/analysis/bounds.py
@@ -117,12 +117,12 @@ class PDF(Bounds):
     def __init__(self, rv):
         super(PDF, self).__init__()
         # we'll accept any object so long as it has logpdf and rvs methods
-        if hasattr(rv, "logpdf") and hasattr(rv, "rvs"):
+        if hasattr(rv, "logpdf") and hasattr(rv, "rvs") and hasattr(rv, "ppf"):
             self.rv = rv
         else:
             raise ValueError(
                 "You must initialise PDF with an object that has"
-                " logpdf and rvs methods"
+                " logpdf, rvs, and ppf methods"
             )
 
     def __repr__(self):

--- a/refnx/analysis/test/test_bounds.py
+++ b/refnx/analysis/test/test_bounds.py
@@ -137,6 +137,9 @@ class UserPDF(object):
 
     def rvs(self, size=1, random_state=None):
         return np.random.random(size)
+    
+    def ppf(self, q):
+        return 1
 
     def invcdf(self, q):
         return 1

--- a/refnx/analysis/test/test_bounds.py
+++ b/refnx/analysis/test/test_bounds.py
@@ -137,7 +137,7 @@ class UserPDF(object):
 
     def rvs(self, size=1, random_state=None):
         return np.random.random(size)
-    
+
     def ppf(self, q):
         return 1
 


### PR DESCRIPTION
For the `invcdf` method of the `PDF` class, the `rv` object needs a `ppf` method. This previously was not reflected in the `__init__`.