### PR TITLE
MAINT: remove some roadblocks to JAXification

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -297,3 +297,5 @@ in 0.1.13.
 0.1.18
 ------
 - SPZ batch reduction
+- remove some roadblocks to JAXification (float casting in Parameter.value
+ setter)

--- a/refnx/analysis/objective.py
+++ b/refnx/analysis/objective.py
@@ -156,11 +156,7 @@ class BaseObjective(object):
             negative log-posterior
 
         """
-        vals = self.parameters
-        if pvals is not None:
-            vals = pvals
-
-        return -self.logpost(vals)
+        return -self.logpost(pvals)
 
     def varying_parameters(self):
         """
@@ -597,8 +593,8 @@ class Objective(BaseObjective):
         logl += (y - model) ** 2 / var_y
 
         # nans play havoc
-        if np.isnan(logl).any():
-            raise RuntimeError("Objective.logl encountered a NaN")
+        # if np.isnan(logl).any():
+        #     raise RuntimeError("Objective.logl encountered a NaN")
 
         # add on extra 'potential' terms from the model.
         extra_potential = self.model.logp()

--- a/refnx/analysis/parameter.py
+++ b/refnx/analysis/parameter.py
@@ -672,8 +672,9 @@ class Parameter(BaseParameter):
 
     @value.setter
     def value(self, v):
-        value = float(v)
-
+        value = v
+        if isinstance(v, (BaseParameter, np.ndarray)):
+            value = float(v)
         self._value = value
 
     def _eval(self):

--- a/refnx/analysis/test/test_curvefitter.py
+++ b/refnx/analysis/test/test_curvefitter.py
@@ -588,6 +588,10 @@ class TestFitterGauss(object):
             self.objective.logp() + self.objective.logl(),
         )
         assert_allclose(self.objective.nlpost(), -self.objective.logpost())
+        assert_allclose(
+            self.objective.nlpost(self.p0),
+            -self.objective.logpost(self.p0)
+        )
 
         # if the priors are all uniform then the only difference between
         # logpost and logl is a constant. A minimiser should converge on the

--- a/refnx/analysis/test/test_curvefitter.py
+++ b/refnx/analysis/test/test_curvefitter.py
@@ -589,8 +589,7 @@ class TestFitterGauss(object):
         )
         assert_allclose(self.objective.nlpost(), -self.objective.logpost())
         assert_allclose(
-            self.objective.nlpost(self.p0),
-            -self.objective.logpost(self.p0)
+            self.objective.nlpost(self.p0), -self.objective.logpost(self.p0)
         )
 
         # if the priors are all uniform then the only difference between


### PR DESCRIPTION
Not sure if this is going to create problems into the future by removing the float cast in the `Parameter.value` setter. However, from testing it does seem to remove some roadblocks when calculating a gradient with JAX.

```
class Line(Model):
    def __init__(self, parameters):
#         super(Line, self).__init__(parameters)
        self._parameters = parameters
    
    def model(self, x, p=None, x_err=None):
        if p is not None:
            self._parameters = p
        a, b = self._parameters
        return a.value + x * b.value

def g(objective):
    obj = objective
    v = np.array(obj.parameters)
    jacobian = jit(grad(obj.nll))
    obj.parameters.pvals = v

    def jac(p):
        v = np.array(p)
        gg = jacobian(v)
        obj.parameters.pvals = v
        return gg
    return jac
```

At the moment it's necessary to create the wrapper for the JAX calculator because the jitted grad function leaves some kind of tracing JAX object in the Parameter rather than a value.