### PR TITLE
Added runtime error to Transform in objective.py

### DIFF
--- a/refnx/analysis/objective.py
+++ b/refnx/analysis/objective.py
@@ -1224,6 +1224,13 @@ class Transform(object):
             yt = np.copy(y)
             et = np.copy(etemp)
         elif self.form == "logY":
+            if (any(i <= 0 for i in y) or
+                (y_err is not None and any(i <= 0 for i in y_err))):
+                raise RuntimeError(
+                    "Some of the transformed data was non-finite."
+                    " Please check your datasets for points with zero or"
+                    " negative values." 
+                )
             yt, et = EP.EPlog10(y, etemp)
         elif self.form == "YX4":
             yt = y * np.power(x, 4)

--- a/refnx/analysis/objective.py
+++ b/refnx/analysis/objective.py
@@ -1224,14 +1224,13 @@ class Transform(object):
             yt = np.copy(y)
             et = np.copy(etemp)
         elif self.form == "logY":
-            if (any(i <= 0 for i in y) or
-                (y_err is not None and any(i <= 0 for i in y_err))):
+            yt, et = EP.EPlog10(y, etemp)
+            if not np.isfinite(yt).all():
                 raise RuntimeError(
                     "Some of the transformed data was non-finite."
                     " Please check your datasets for points with zero or"
-                    " negative values." 
+                    " negative values."
                 )
-            yt, et = EP.EPlog10(y, etemp)
         elif self.form == "YX4":
             yt = y * np.power(x, 4)
             et = etemp * np.power(x, 4)


### PR DESCRIPTION
Added a `RuntimeError` to `Transform` for non-finite transformed values when using the logY transform. This should address issue #522.