### PR TITLE
MAINT: check transform for non-finite'

### DIFF
--- a/refnx/analysis/objective.py
+++ b/refnx/analysis/objective.py
@@ -1231,7 +1231,7 @@ class Transform(object):
                     "Some of the transformed data was non-finite."
                     " Please check your datasets for points with zero or"
                     " negative values.",
-                    RuntimeWarning
+                    RuntimeWarning,
                 )
         elif self.form == "YX4":
             yt = y * np.power(x, 4)

--- a/refnx/analysis/objective.py
+++ b/refnx/analysis/objective.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 from numpy.linalg import LinAlgError
 from scipy.optimize._numdiff import approx_derivative
@@ -593,8 +594,8 @@ class Objective(BaseObjective):
         logl += (y - model) ** 2 / var_y
 
         # nans play havoc
-        # if np.isnan(logl).any():
-        #     raise RuntimeError("Objective.logl encountered a NaN")
+        if np.isnan(logl).any():
+            raise RuntimeError("Objective.logl encountered a NaN.")
 
         # add on extra 'potential' terms from the model.
         extra_potential = self.model.logp()
@@ -1226,10 +1227,11 @@ class Transform(object):
         elif self.form == "logY":
             yt, et = EP.EPlog10(y, etemp)
             if not np.isfinite(yt).all():
-                raise RuntimeError(
+                warnings.warn(
                     "Some of the transformed data was non-finite."
                     " Please check your datasets for points with zero or"
-                    " negative values."
+                    " negative values.",
+                    RuntimeWarning
                 )
         elif self.form == "YX4":
             yt = y * np.power(x, 4)


### PR DESCRIPTION
Downgrade a RuntimeError to RuntimeWarning. This is because the GUI app would have to jump through too many hoops to filter negative values for logY transform.