### PR TITLE
ENH: `possibly_create_parameter` and `is_parameter` now use `BasePara…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -306,3 +306,8 @@ in 0.1.13.
 - RuntimeError if a log transform creates non-finite numbers.
 - ReflectModels can now use a q_offset to correct for possible angular
   misalignments.
+- `possibly_create_parameter` and `is_parameter` now use `BaseParameter` for
+  their operation, rather than `Parameter`. Thus _BinaryOp and _UnaryOp can be
+  given to these operations and work. This enables construction of various
+  objects (SLD/Slab/etc) from constrained parameters, rather than setting a
+  constraint afterwards.

--- a/refnx/analysis/parameter.py
+++ b/refnx/analysis/parameter.py
@@ -825,7 +825,7 @@ class _UnaryOp(BaseParameter):
 
 def is_parameter(x):
     """Test for Parameter-ness."""
-    return isinstance(x, Parameter)
+    return isinstance(x, BaseParameter)
 
 
 def is_parameters(x):

--- a/refnx/analysis/test/test_parameter.py
+++ b/refnx/analysis/test/test_parameter.py
@@ -14,6 +14,8 @@ from refnx.analysis.parameter import (
     constraint_tree,
     build_constraint_from_tree,
     possibly_create_parameter,
+    is_parameter,
+    _BinaryOp,
 )
 
 
@@ -73,6 +75,13 @@ class TestParameter(object):
 
         x.value = 10
         assert_equal(y.value, 2.0 + np.sin(10))
+
+    def test_is_parameter(self):
+        p = Parameter(1.0)
+        assert is_parameter(p)
+
+        assert isinstance(0.5 * p, _BinaryOp)
+        assert is_parameter(0.5 * p)
 
     def test_repr(self):
         p = Parameter(value=5, name="pop", vary=True)
@@ -229,6 +238,9 @@ class TestParameter(object):
         assert_allclose(q.bounds.lb, -1)
         assert_allclose(q.bounds.ub, 2.0)
         assert q.vary
+
+        q = possibly_create_parameter(0.5 * p)
+        assert isinstance(q, _BinaryOp)
 
 
 class TestParameters(object):

--- a/refnx/reduce/manual_beam_finder.py
+++ b/refnx/reduce/manual_beam_finder.py
@@ -283,7 +283,8 @@ class ManualBeamFinder(QtWidgets.QDialog):
         xs = xs[in_foreground]
 
         # calculate peak centre
-        self._true_centre, self._true_sd = peak_finder(xs, x=x)[1]
+        self._true_centre, _ = peak_finder(xs, x=x)[1]
+        self._true_sd = (hipx - lopx) / 4.0
 
         # redraw beam centre on detector image and cross section
         self.cross_section.l_bc.set_xdata(self._true_centre)

--- a/refnx/reflect/structure.py
+++ b/refnx/reflect/structure.py
@@ -37,6 +37,7 @@ except ImportError:
 
 from refnx._lib import flatten
 from refnx.analysis import Parameters, Parameter, possibly_create_parameter
+from refnx.analysis.parameter import BaseParameter
 from refnx.reflect.interface import Interface, Erf, Step
 from refnx.reflect.reflect_model import get_reflect_backend
 
@@ -792,12 +793,12 @@ class SLD(Scatterer):
         elif isinstance(value, SLD):
             self.real = value.real
             self.imag = value.imag
-        elif isinstance(value, Parameter):
+        elif isinstance(value, BaseParameter):
             self.real = value
         elif (
             hasattr(value, "__len__")
-            and isinstance(value[0], Parameter)
-            and isinstance(value[1], Parameter)
+            and isinstance(value[0], BaseParameter)
+            and isinstance(value[1], BaseParameter)
         ):
             self.real = value[0]
             self.imag = value[1]

--- a/refnx/reflect/test/test_structure.py
+++ b/refnx/reflect/test/test_structure.py
@@ -334,7 +334,6 @@ class TestStructure(object):
 
         # check that we can construct SLDs from a constrained par
         deut_par = Parameter(6.36)
-        deut_solvent = SLD(deut_par)
         h2o_solvent = SLD(-0.56)
 
         ms_val = 0.6 * deut_par + 0.4 * h2o_solvent.real

--- a/refnx/reflect/test/test_structure.py
+++ b/refnx/reflect/test/test_structure.py
@@ -24,6 +24,7 @@ from refnx.reflect import (
 )
 from refnx.reflect.structure import _profile_slicer
 from refnx.analysis import Parameter, Interval, Parameters
+from refnx.analysis.parameter import _BinaryOp
 
 
 class TestStructure(object):
@@ -330,6 +331,21 @@ class TestStructure(object):
         assert_equal(s.thick.value, thickness.value)
         assert_equal(s.rough.value, roughness.value)
         assert_equal(s.vfsolv.value, vfsolv.value)
+
+        # check that we can construct SLDs from a constrained par
+        deut_par = Parameter(6.36)
+        deut_solvent = SLD(deut_par)
+        h2o_solvent = SLD(-0.56)
+
+        ms_val = 0.6 * deut_par + 0.4 * h2o_solvent.real
+        mixed_solvent = SLD(ms_val)
+        assert isinstance(mixed_solvent.real, _BinaryOp)
+        sld = complex(mixed_solvent)
+        assert_allclose(sld.real, 0.6 * 6.36 + 0.4 * -0.56)
+
+        deut_par.value = 5.0
+        sld = complex(mixed_solvent)
+        assert_allclose(sld.real, 0.6 * 5.0 + 0.4 * -0.56)
 
     def test_sld_slicer(self):
         q = np.linspace(0.005, 0.2, 100)


### PR DESCRIPTION
…meter` for

  their operation, rather than `Parameter`. Thus _BinaryOp and _UnaryOp can be
  given to these operations and work. This enables construction of various
  objects (SLD/Slab/etc) from constrained parameters, rather than setting a
  constraint afterwards.