### PR TITLE
Spinset classes

### DIFF
--- a/refnx/reduce/__init__.py
+++ b/refnx/reduce/__init__.py
@@ -14,6 +14,8 @@ from refnx.reduce.platypusnexus import (
     Catalogue,
     SpatzNexus,
     ReductionOptions,
+    SpinChannel,
+    SpinSet,
 )
 from refnx.reduce.batchreduction import BatchReducer
 from refnx.reduce.xray import reduce_xrdml

--- a/refnx/reduce/platypusnexus.py
+++ b/refnx/reduce/platypusnexus.py
@@ -642,8 +642,6 @@ class SpinSet(object):
     """
     Describes a set of spin-channels at a given angle.
 
-    TODO: implement polarisation efficiency correction within this class
-
     Parameters
     ----------
     list of {str, h5data}
@@ -652,6 +650,18 @@ class SpinSet(object):
 
     data_folder: {str, Path}
         Path to the data folder containing the data to be reduced.
+
+    Attributes
+    ----------
+    dd_opts : refnx.reduce.ReductionOptions
+    du_opts : refnx.reduce.ReductionOptions
+    ud_opts : refnx.reduce.ReductionOptions
+    uu_opts : refnx.reduce.ReductionOptions
+
+    Notes
+    -----
+    Each of the `ReductionOptions` specified in `dd_opts,` etc, is used
+    to specify
     """
 
     def __init__(
@@ -715,15 +725,15 @@ class SpinSet(object):
             for s in [self.dd, self.du, self.ud, self.uu]
         ]
 
-    def process_beams(self, reduction_options=None):
+    def _process_beams(self, reduction_options=None):
         """
         Process beams in SpinSet.
 
         Reduction options for each spin channel are specified by
-        self.dd_opts, self.du_opts, self.ud_opts, and self.uu_opts where
-        a standard set of options is provided when constructing the object.
-        To specify different options for each spin channel (such as using
-        the ManualBeamFinder for only spin-flip channels), update the
+        SpinSet.dd_opts, SpinSet.du_opts, SpinSet.ud_opts, and SpinSet.uu_opts
+        where a standard set of options is provided when constructing the
+        object. To specify different options for each spin channel (such as
+        using the ManualBeamFinder for only spin-flip channels), update the
         reduction options for the specific spin channel in SpinSet, then
         process the beams. i.e.
 
@@ -747,7 +757,8 @@ class SpinSet(object):
             this is None, then process_beams will use individual dicts
             for each spin channel
         """
-
+        # TODO consider removing this method, not clear how it's going to be
+        # used.
         if reduction_options:
             print(
                 "Applying the supplied reduction_options to all spin channels"

--- a/refnx/reduce/test/test_platypusnexus.py
+++ b/refnx/reduce/test/test_platypusnexus.py
@@ -71,19 +71,19 @@ class TestSpinSet(object):
         assert self.spinset_2.spin_channels == [(0, 0), None, None, (1, 1)]
 
     def test_process_beams(self):
-        self.spinset.process_beams()
+        self.spinset._process_beams()
         assert self.spinset.dd.processed_spectrum
         assert self.spinset.du.processed_spectrum
         assert self.spinset.ud.processed_spectrum
         assert self.spinset.uu.processed_spectrum
 
-        self.spinset_3.process_beams()
+        self.spinset_3._process_beams()
         assert self.spinset_3.dd.processed_spectrum
         assert self.spinset_3.du.processed_spectrum
         assert self.spinset_3.ud is None
         assert self.spinset_3.uu.processed_spectrum
 
-        self.spinset_2.process_beams()
+        self.spinset_2._process_beams()
         assert self.spinset_2.dd.processed_spectrum
         assert self.spinset_2.du is None
         assert self.spinset_2.ud is None


### PR DESCRIPTION
Adding classes for SpinChannel and SpinSet. 

SpinChannel is an Enum class specifying the spin state in a PlatypusNexus file/

SpinSet is a set of up to 4 spin channels that are kept together for polarisation efficiency correction as well as for use in a future PolarisedReduce class for reducing multiple spin-polarised datasets. 