### PR TITLE
Flaky test fix

### DIFF
--- a/refnx/analysis/test/test_curvefitter.py
+++ b/refnx/analysis/test/test_curvefitter.py
@@ -576,7 +576,7 @@ class TestFitterGauss(object):
         for method in methods:
             self.objective.setp(self.p0)
             res = f.fit(method=method)
-            assert_almost_equal(res.x, self.best_weighted, 3)
+            assert_almost_equal(res.x, self.best_weighted, 1)
 
         # smoke test to check that we can use nlpost
         self.objective.setp(self.p0)


### PR DESCRIPTION
Hi,

The test `test_all_minimisers` sometimes fails non-deterministically. The assertion uses a higher precision than what might be needed. This PR fixes this issue.

To find a solution, I collected samples for `abs(res.x- self.best_weighted)` from several test executions and computed the tail distribution. I computed the extreme percentiles to check how high can the difference be. Based on the 99.99th percentile, it seems changing the decimal places to 1 might reduce the chances of failure here. I think setting the bound using the statistical evaluation might be a good way to ensure the test is not flaky.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions. Also, here I assume there are no bugs in the code under test.

