### PR TITLE
Test that multidimensional data can work

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -339,3 +339,5 @@ in 0.1.13.
 
 0.1.21
 ------
+- check that refnx/analysis doesn't get in the way of handling
+  multidimensional data.

--- a/refnx/analysis/objective.py
+++ b/refnx/analysis/objective.py
@@ -360,6 +360,13 @@ class Objective(BaseObjective):
         return p
 
     def _data_transform(self, model=None):
+        """
+        Returns
+        -------
+        y, y_err, model: tuple of np.ndarray
+            The y data, its uncertainties, and the model, all put through the
+             transform.
+        """
         x = self.data.x
         y = self.data.y
 
@@ -426,7 +433,7 @@ class Objective(BaseObjective):
         else:
             s_n = y_err
 
-        return np.squeeze((y - model) / s_n)
+        return (y - model) / s_n
 
     def chisqr(self, pvals=None):
         """
@@ -446,7 +453,7 @@ class Objective(BaseObjective):
         # TODO reduced chisqr? include z-scores for parameters? DOF?
         self.setp(pvals)
         res = self.residuals(None)
-        return np.dot(res, res)
+        return np.sum(res * res)
 
     @property
     def parameters(self):

--- a/refnx/analysis/test/test_model.py
+++ b/refnx/analysis/test/test_model.py
@@ -29,7 +29,6 @@ def line_ND(x, params):
     p_arr = np.array(params)
     y0 = p_arr[0] + x[0] * p_arr[1]
     y1 = p_arr[0] + x[1] * p_arr[1]
-    print(y0.shape, y1.shape)
     return np.vstack((y0, y1))
 
 

--- a/refnx/analysis/test/test_objective.py
+++ b/refnx/analysis/test/test_objective.py
@@ -562,4 +562,4 @@ class TestObjective:
         objective.logl()
         objective.logpost()
         covar = objective.covar()
-        assert covar.shape == (2, 3)
+        assert covar.shape == (2, 2)

--- a/refnx/dataset/data1d.py
+++ b/refnx/dataset/data1d.py
@@ -117,30 +117,31 @@ class Data1D:
         """
         np.ndarray : x data (possibly masked)
         """
-        if self._x.size > 0:
+        if self._mask is not None and self._x.size:
             return self._x[self.mask]
-        else:
-            return self._x
+        return self._x
 
     @property
     def y(self):
         """
         np.ndarray : y data (possibly masked)
         """
-        if self._y.size > 0:
+        if self._mask is not None and self._y.size:
             return self._y[self.mask]
-        else:
-            return self._y
+        return self._y
 
     @property
     def x_err(self):
         """
         np.ndarray : x uncertainty (possibly masked)
         """
-        if self._x_err is not None:
+        if (
+            self._x_err is not None
+            and self._mask is not None
+            and self._x_err.size
+        ):
             return self._x_err[self.mask]
-        else:
-            return self._x_err
+        return self._x_err
 
     @x_err.setter
     def x_err(self, x_err):
@@ -154,10 +155,13 @@ class Data1D:
         """
         uncertainties on the y data (possibly masked)
         """
-        if self._y_err is not None:
+        if (
+            self._y_err is not None
+            and self._mask is not None
+            and self._y_err.size
+        ):
             return self._y_err[self.mask]
-        else:
-            return self._y_err
+        return self._y_err
 
     @property
     def mask(self):

--- a/refnx/dataset/test/test_reflectdataset.py
+++ b/refnx/dataset/test/test_reflectdataset.py
@@ -272,7 +272,7 @@ class TestReflectDataset:
         assert_equal(len(b), len(a))
 
 
-class TestData1D():
+class TestData1D:
     @pytest.fixture(autouse=True)
     def setup_method(self, tmpdir):
         self.pth = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
When fitting something like ellipsometry data the datasets have four values associated with each datapoint, rather than an x/y pair. Viz: the independent variables are `wavelength` and `AOI`, with the dependent variables being `xsi` and `delta`.

The existing refnx analysis code should be already able to handle this in the `Data1D/Model/Objective` framework, so long as the user writes fitfuncs/creates datasets that are consistent with each other.

This PR adds tests to ensure that the analysis code handles this kind of situation correctly. i.e. that a Data1D can have a `y` attribute of shape `(N, M)` and an `x` attribute of shape `(P, Q)`; that a call of Model(x) gives an array of shape `(N, M)`, and that the `Objective` statistics (generative, chisqr, logpost, residuals) are calculated correctly.

This might simplify refellips considerably.

@igresh @haydenrob 