### PR TITLE
Remove `data_folder` kwd from `SpinSet` initialisation

### DIFF
--- a/refnx/reduce/platypusnexus.py
+++ b/refnx/reduce/platypusnexus.py
@@ -527,9 +527,9 @@ class PolarisedCatalogue(PlatypusCatalogue):
         self.is_power_supply = False
 
         d = self.cat
-        d = self._polariser_flippers(d, h5d)
-        d = self._analyser_flippers(d, h5d)
-        d = self._check_sample_environments(d, h5d)
+        self._polariser_flippers(d, h5d)
+        self._analyser_flippers(d, h5d)
+        self._check_sample_environments(d, h5d)
 
     def _polariser_flippers(self, d, h5d):
         d["pol_flip_freq"] = h5d[
@@ -547,7 +547,6 @@ class PolarisedCatalogue(PlatypusCatalogue):
         d["pol_guide_current"] = h5d[
             "entry1/instrument/polarizer_flipper/guide_current"
         ][0]
-        return d
 
     def _analyser_flippers(self, d, h5d):
         d["anal_flip_freq"] = h5d[
@@ -569,7 +568,6 @@ class PolarisedCatalogue(PlatypusCatalogue):
         d["anal_dist"] = h5d["entry1/instrument/polarizer/anal_distance"][0]
         d["rotation"] = h5d["entry1/instrument/polarizer/rotation"][0]
         d["z_trans"] = h5d["entry1/instrument/polarizer/z_translation"][0]
-        return d
 
     def _check_sample_environments(self, d, h5d):
         try:
@@ -628,7 +626,6 @@ class PolarisedCatalogue(PlatypusCatalogue):
             d["magnet_measured_field"] = None
             d["magnet_output_current"] = None
             self.is_magnet = False
-        return d
 
 
 class SpinChannel(Enum):
@@ -661,9 +658,6 @@ class SpinSet(object):
     up_down     :   str or refnx.reduce.PlatypusNexus, optional
         Input filename or PlatypusNexus object for the R+- spin
         channel.
-
-    data_folder: {str, Path}, optional
-        Path to the data folder containing the data to be reduced.
 
     Attributes
     ----------
@@ -699,11 +693,10 @@ class SpinSet(object):
     """
 
     def __init__(
-        self, down_down, up_up, down_up=None, up_down=None, data_folder=None
+        self, down_down, up_up, down_up=None, up_down=None
     ):
         # Currently only Platypus has polarisation elements
         self.reflect_klass = PlatypusNexus
-        self.data_folder = data_folder
 
         # initialise spin channels
         self.channels = {
@@ -750,8 +743,9 @@ class SpinSet(object):
                 channel = input_param
             else:
                 # Spin channel inputted as file string
-                fpath = os.path.join(data_folder, input_param)
-                channel = self.reflect_klass(fpath)
+                channel = self.reflect_klass(input_param)
+
+            print(sc, input_param, channel.spin_state, _spin_channels[sc])
             if channel.spin_state is _spin_channels[sc]:
                 self.channels[sc] = channel
                 self.sc_opts[sc] = reduction_options.copy()

--- a/refnx/reduce/platypusnexus.py
+++ b/refnx/reduce/platypusnexus.py
@@ -692,9 +692,7 @@ class SpinSet(object):
     wavelength_bins  : key in refnx.reduce.ReductionOptions
     """
 
-    def __init__(
-        self, down_down, up_up, down_up=None, up_down=None
-    ):
+    def __init__(self, down_down, up_up, down_up=None, up_down=None):
         # Currently only Platypus has polarisation elements
         self.reflect_klass = PlatypusNexus
 

--- a/refnx/reduce/platypusnexus.py
+++ b/refnx/reduce/platypusnexus.py
@@ -745,7 +745,7 @@ class SpinSet(object):
                 # Spin channel inputted as file string
                 channel = self.reflect_klass(input_param)
 
-            print(sc, input_param, channel.spin_state, _spin_channels[sc])
+            # print(sc, input_param, channel.spin_state, _spin_channels[sc])
             if channel.spin_state is _spin_channels[sc]:
                 self.channels[sc] = channel
                 self.sc_opts[sc] = reduction_options.copy()

--- a/refnx/reduce/reduce.py
+++ b/refnx/reduce/reduce.py
@@ -784,6 +784,7 @@ class PolarisedReduce:
         for sc in ["dd", "du"]:
             self.reducers[sc] = PlatypusReduce(spin_set_direct.dd)
         for sc in ["ud", "uu"]:
+            print(spin_set_direct.uu)
             self.reducers[sc] = PlatypusReduce(spin_set_direct.uu)
 
     def __call__(self, spin_set_reflect, pol_eff=None, **reduction_options):

--- a/refnx/reduce/test/test_platypusnexus.py
+++ b/refnx/reduce/test/test_platypusnexus.py
@@ -39,27 +39,26 @@ class TestSpinSet(object):
     def setup_method(self, tmpdir, data_directory):
         self.pth = pjoin(data_directory, "reduce", "PNR_files")
 
+        fpath = lambda f: pjoin(self.pth, f)
+
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)
 
             self.spinset = SpinSet(
-                down_down="PLP0008864.nx.hdf",
-                up_up="PLP0008861.nx.hdf",
-                down_up="PLP0008863.nx.hdf",
-                up_down="PLP0008862.nx.hdf",
-                data_folder=self.pth,
+                down_down=fpath("PLP0008864.nx.hdf"),
+                up_up=fpath("PLP0008861.nx.hdf"),
+                down_up=fpath("PLP0008863.nx.hdf"),
+                up_down=fpath("PLP0008862.nx.hdf"),
             )
 
             self.spinset_3 = SpinSet(
-                down_down="PLP0008864.nx.hdf",
-                up_up="PLP0008861.nx.hdf",
-                down_up="PLP0008863.nx.hdf",
-                data_folder=self.pth,
+                down_down=fpath("PLP0008864.nx.hdf"),
+                up_up=fpath("PLP0008861.nx.hdf"),
+                down_up=fpath("PLP0008863.nx.hdf"),
             )
             self.spinset_2 = SpinSet(
-                down_down="PLP0008864.nx.hdf",
-                up_up="PLP0008861.nx.hdf",
-                data_folder=self.pth,
+                down_down=fpath("PLP0008864.nx.hdf"),
+                up_up=fpath("PLP0008861.nx.hdf"),
             )
 
         self.cwd = os.getcwd()

--- a/refnx/reduce/test/test_platypusnexus.py
+++ b/refnx/reduce/test/test_platypusnexus.py
@@ -39,7 +39,8 @@ class TestSpinSet(object):
     def setup_method(self, tmpdir, data_directory):
         self.pth = pjoin(data_directory, "reduce", "PNR_files")
 
-        fpath = lambda f: pjoin(self.pth, f)
+        def fpath(f):
+            return pjoin(self.pth, f)
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)

--- a/refnx/reduce/test/test_reduce.py
+++ b/refnx/reduce/test/test_reduce.py
@@ -246,18 +246,16 @@ class TestPolarisedReduce:
             warnings.simplefilter("ignore", RuntimeWarning)
 
             spinset_rb = SpinSet(
-                down_down="PLP0012785.nx.hdf",
-                up_up="PLP0012787.nx.hdf",
-                up_down="PLP0012786.nx.hdf",
-                down_up="PLP0012788.nx.hdf",
-                data_folder=self.pth,
+                down_down=pjoin(self.pth, "PLP0012785.nx.hdf"),
+                up_up=pjoin(self.pth, "PLP0012787.nx.hdf"),
+                up_down=pjoin(self.pth, "PLP0012786.nx.hdf"),
+                down_up=pjoin(self.pth, "PLP0012788.nx.hdf"),
             )
             spinset_db = SpinSet(
-                down_down="PLP0012793.nx.hdf",
-                up_up="PLP0012795.nx.hdf",
-                up_down="PLP0012794.nx.hdf",
-                down_up="PLP0012796.nx.hdf",
-                data_folder=self.pth,
+                down_down=pjoin(self.pth, "PLP0012793.nx.hdf"),
+                up_up=pjoin(self.pth, "PLP0012795.nx.hdf"),
+                up_down=pjoin(self.pth, "PLP0012794.nx.hdf"),
+                down_up=pjoin(self.pth, "PLP0012796.nx.hdf"),
             )
             a = PolarisedReduce(spinset_db)
 
@@ -354,16 +352,14 @@ class TestPolarisedReduce:
             warnings.simplefilter("ignore", RuntimeWarning)
 
             spinset_rb = SpinSet(
-                down_down="PLP0012785.nx.hdf",
-                up_up="PLP0012787.nx.hdf",
-                up_down="PLP0012786.nx.hdf",
-                data_folder=self.pth,
+                down_down=pjoin(self.pth, "PLP0012785.nx.hdf"),
+                up_up=pjoin(self.pth, "PLP0012787.nx.hdf"),
+                up_down=pjoin(self.pth, "PLP0012786.nx.hdf"),
             )
             spinset_db = SpinSet(
-                down_down="PLP0012793.nx.hdf",
-                up_up="PLP0012795.nx.hdf",
-                up_down="PLP0012794.nx.hdf",
-                data_folder=self.pth,
+                down_down=pjoin(self.pth, "PLP0012793.nx.hdf"),
+                up_up=pjoin(self.pth, "PLP0012795.nx.hdf"),
+                up_down=pjoin(self.pth, "PLP0012794.nx.hdf"),
             )
             a = PolarisedReduce(spinset_db)
 
@@ -459,14 +455,12 @@ class TestPolarisedReduce:
             warnings.simplefilter("ignore", RuntimeWarning)
 
             spinset_rb = SpinSet(
-                down_down="PLP0012785.nx.hdf",
-                up_up="PLP0012787.nx.hdf",
-                data_folder=self.pth,
+                down_down=pjoin(self.pth, "PLP0012785.nx.hdf"),
+                up_up=pjoin(self.pth, "PLP0012787.nx.hdf"),
             )
             spinset_db = SpinSet(
-                down_down="PLP0012793.nx.hdf",
-                up_up="PLP0012795.nx.hdf",
-                data_folder=self.pth,
+                down_down=pjoin(self.pth, "PLP0012793.nx.hdf"),
+                up_up=pjoin(self.pth, "PLP0012795.nx.hdf"),
             )
             a = PolarisedReduce(spinset_db)
 
@@ -557,14 +551,12 @@ class TestPolarisedReduce:
             warnings.simplefilter("ignore", RuntimeWarning)
 
             spinset_rb = SpinSet(
-                down_down="PLP0012785.nx.hdf",
-                up_up="PLP0012787.nx.hdf",
-                data_folder=self.pth,
+                down_down=pjoin(self.pth, "PLP0012785.nx.hdf"),
+                up_up=pjoin(self.pth, "PLP0012787.nx.hdf"),
             )
             spinset_db = SpinSet(
-                down_down="PLP0012793.nx.hdf",
-                up_up="PLP0012795.nx.hdf",
-                data_folder=self.pth,
+                down_down=pjoin(self.pth, "PLP0012793.nx.hdf"),
+                up_up=pjoin(self.pth, "PLP0012795.nx.hdf"),
             )
             a = PolarisedReduce(spinset_db)
 
@@ -647,14 +639,12 @@ class TestPolarisationEfficiency:
 
             # Create SpinSets, PolarisedReduce object and ReductionOptions
             spinset_rb = SpinSet(
-                down_down="PLP0012785.nx.hdf",
-                up_up="PLP0012787.nx.hdf",
-                data_folder=self.pth,
+                down_down=pjoin(self.pth, "PLP0012785.nx.hdf"),
+                up_up=pjoin(self.pth, "PLP0012787.nx.hdf"),
             )
             spinset_db = SpinSet(
-                down_down="PLP0012793.nx.hdf",
-                up_up="PLP0012795.nx.hdf",
-                data_folder=self.pth,
+                down_down=pjoin(self.pth, "PLP0012793.nx.hdf"),
+                up_up=pjoin(self.pth, "PLP0012795.nx.hdf"),
             )
             a = PolarisedReduce(spinset_db)
 


### PR DESCRIPTION
SpinSets should be constructed with a fully qualified filename. This removes the data_folder keyword argument. 