### PR TITLE
MAINT: improve spin_state detection

### DIFF
--- a/refnx/reduce/platypusnexus.py
+++ b/refnx/reduce/platypusnexus.py
@@ -2153,23 +2153,33 @@ class PlatypusNexus(ReflectNexus):
                 self.cat = PolarisedCatalogue(f)
 
                 # Set spin channels based of flipper statuses
-                if self.cat.pol_flip_current and self.cat.anal_flip_current:
-                    self.spin_state = SpinChannel.UP_UP
-                elif (
-                    self.cat.pol_flip_current
-                    and not self.cat.anal_flip_current
-                ):
-                    self.spin_state = SpinChannel.UP_DOWN
-                elif (
-                    not self.cat.pol_flip_current
-                    and self.cat.anal_flip_current
-                ):
-                    self.spin_state = SpinChannel.DOWN_UP
-                elif (
-                    not self.cat.pol_flip_current
-                    and not self.cat.anal_flip_current
-                ):
-                    self.spin_state = SpinChannel.DOWN_DOWN
+                if self.cat.mode == "POL":
+                    if self.cat.pol_flip_current > 0.1:
+                        self.spin_state = SpinChannel.UP_UP
+                    else:
+                        self.spin_state = SpinChannel.DOWN_DOWN
+
+                if self.cat.mode == "POLANAL":
+                    if (
+                        self.cat.pol_flip_current > 0.1
+                        and self.cat.anal_flip_current > 0.1
+                    ):
+                        self.spin_state = SpinChannel.UP_UP
+                    elif (
+                        self.cat.pol_flip_current > 0.1
+                        and self.cat.anal_flip_current < 0.1
+                    ):
+                        self.spin_state = SpinChannel.UP_DOWN
+                    elif (
+                        self.cat.pol_flip_current < 0.1
+                        and self.cat.anal_flip_current > 0.1
+                    ):
+                        self.spin_state = SpinChannel.DOWN_UP
+                    elif (
+                        self.cat.pol_flip_current < 0.1
+                        and self.cat.anal_flip_current < 0.1
+                    ):
+                        self.spin_state = SpinChannel.DOWN_DOWN
 
     def detector_average_unwanted_direction(self, detector):
         """

--- a/refnx/reduce/reduce.py
+++ b/refnx/reduce/reduce.py
@@ -784,7 +784,6 @@ class PolarisedReduce:
         for sc in ["dd", "du"]:
             self.reducers[sc] = PlatypusReduce(spin_set_direct.dd)
         for sc in ["ud", "uu"]:
-            print(spin_set_direct.uu)
             self.reducers[sc] = PlatypusReduce(spin_set_direct.uu)
 
     def __call__(self, spin_set_reflect, pol_eff=None, **reduction_options):

--- a/refnx/reduce/test/test_platypusnexus.py
+++ b/refnx/reduce/test/test_platypusnexus.py
@@ -475,6 +475,7 @@ class TestPlatypusNexus(object):
         assert_almost_equal(self.f8861.cat.cat["magnet_current_set"], 0)
         assert_almost_equal(self.f8861.cat.cat["magnet_output_current"], 0.001)
 
+
 class TestSpatzNexus:
     @pytest.mark.usefixtures("no_data_directory")
     @pytest.fixture(autouse=True)

--- a/refnx/reduce/test/test_platypusnexus.py
+++ b/refnx/reduce/test/test_platypusnexus.py
@@ -464,10 +464,11 @@ class TestPlatypusNexus(object):
         assert self.f8864.spin_state == SpinChannel.DOWN_DOWN
 
         # test spin channel setting
-        # non spin analysed. The polariser flipper is on, analyser flipper off
-        # but the experimental mode is POL and z_trans is -200.
+        # non spin analysed. mode is POL, not POLANAL
         pn = PlatypusNexus(pjoin(self.pth, "PLP0016427.nx.hdf"))
         assert pn.spin_state == SpinChannel.UP_UP
+        pn = PlatypusNexus(pjoin(self.pth, "PLP0016426.nx.hdf"))
+        assert pn.spin_state == SpinChannel.DOWN_DOWN
 
     def test_PNR_magnet_read(self):
         self.f8861.process()

--- a/refnx/reduce/test/test_platypusnexus.py
+++ b/refnx/reduce/test/test_platypusnexus.py
@@ -463,12 +463,17 @@ class TestPlatypusNexus(object):
         assert self.f8863.spin_state == SpinChannel.DOWN_UP
         assert self.f8864.spin_state == SpinChannel.DOWN_DOWN
 
+        # test spin channel setting
+        # non spin analysed. The polariser flipper is on, analyser flipper off
+        # but the experimental mode is POL and z_trans is -200.
+        pn = PlatypusNexus(pjoin(self.pth, "PLP0016427.nx.hdf"))
+        assert pn.spin_state == SpinChannel.UP_UP
+
     def test_PNR_magnet_read(self):
         self.f8861.process()
         # Check magnetic field sensors
         assert_almost_equal(self.f8861.cat.cat["magnet_current_set"], 0)
         assert_almost_equal(self.f8861.cat.cat["magnet_output_current"], 0.001)
-
 
 class TestSpatzNexus:
     @pytest.mark.usefixtures("no_data_directory")


### PR DESCRIPTION
Improves spin_state detection. If the mode is `POL` then don't look at the analyser to specify the spin state.
Also changes the way the currents are examined. It's not a good idea to check if a current is equal to zero because equality checks for floating point values are a bad idea TM. Thus to check if a flipper is on or off make examine if the current is less than 0.1 A (OFF) or greater (ON). It might be preferable to check for `pn.cat.pol_flip_status` or `pn.cat.anal_flip_status` instead of current.