### PR TITLE
REL: v0.1.24

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ HAS_OPENMP = check_openmp_support()
 MAJOR = 0
 MINOR = 1
 MICRO = 24
-ISRELEASED = False
+ISRELEASED = True
 VERSION = f"{MAJOR}.{MINOR}.{MICRO}"
 
 


### PR DESCRIPTION
Cutting a new release so that universal macOS wheels are available, and so that wheels can be built with oldest supported numpy, which means that the wheel doesn't require the latest numpy be installed.