### PR TITLE
MAINT: use setuptools ccompiler

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -114,7 +114,6 @@ jobs:
 
     - name: Make wheel
       env:
-        MACOSX_DEPLOYMENT_TARGET: 10.9
         CC: /usr/bin/clang
         CXX: /usr/bin/clang++
         CXXFLAGS: "-Xpreprocessor -fopenmp -I/usr/local/opt/libomp/include"

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,6 @@ else:
     USE_CYTHON = True
 
 
-if platform.system() == "Darwin":
-    os.environ.setdefault("MACOSX_DEPLOYMENT_TARGET", "10.9")
-
-
 ###############################################################################
 """
 Is openMP usable?
@@ -83,9 +79,9 @@ def check_openmp_support():
 
     try:
         from setuptools._distutils.ccompiler import new_compiler
-        # from setuptools._distutils.sysconfig import customize_compiler
+        from setuptools._distutils.sysconfig import customize_compiler
         # from numpy.distutils.ccompiler import new_compiler
-        from distutils.sysconfig import customize_compiler
+        # from distutils.sysconfig import customize_compiler
         from distutils.errors import CompileError, LinkError
     except ImportError:
         return False
@@ -333,9 +329,9 @@ def setup_package():
             # the `-std=c++11` compile arg and C99 C code are incompatible
             # (at least on Darwin).
             from setuptools._distutils.ccompiler import new_compiler
-            # from setuptools._distutils.sysconfig import customize_compiler
+            from setuptools._distutils.sysconfig import customize_compiler
             # from numpy.distutils.ccompiler import new_compiler
-            from distutils.sysconfig import customize_compiler
+            # from distutils.sysconfig import customize_compiler
 
             ccompiler = new_compiler()
             customize_compiler(ccompiler)


### PR DESCRIPTION
distutils is deprecated and removed in Python 3.12. This PR is an approach to start moving away from this.