### PR TITLE
MAINT: Fix generating pandas summary from batch reducer

### DIFF
--- a/refnx/reduce/batchreduction.py
+++ b/refnx/reduce/batchreduction.py
@@ -270,7 +270,7 @@ class ReductionCache(list):
         df = pd.DataFrame(columns=self[0].entry.axes)
         for i, entry in enumerate(self):
             if entry is not None:
-                df.loc[i] = entry.entry
+                df.loc[i] = list(entry.entry)
         return df
 
     def write_cache(self, filename=None):


### PR DESCRIPTION
A change to pandas (at some stage) broke the summary feature of the batch reduction cache. Going via a list lets it work once more.