### PR TITLE
New blend_data function to combine weighted datasets, and small method changes for Data1D

### DIFF
--- a/refnx/dataset/data1d.py
+++ b/refnx/dataset/data1d.py
@@ -444,11 +444,12 @@ class Data1D:
         #   Assume Q values are not the same,
         #   and perhaps density is different between data..
         xovlp = x[overlap_points]  # 1st obj restricted domain
-        Qmin = np.min(xovlp)
+        # Qmin = np.min(xovlp) #Minimum Q in overlap reigon.
         Qmax = x[-1]  # largest value.
         rd1_len = np.sum(overlap_points)  # number of points overlapping
         # Use one bound with equality to ensure n-1 points if x values are identitcal.
-        rd2_overlap = (bx < Qmax) & (bx >= Qmin)
+        rd2_overlap = (bx < Qmax) #Assume all Q < Qmax are valid in overlap.
+        # rd2_overlap = (bx < Qmax) & (bx >= Qmin) #Commented as sometimes bx[0].x < Qmin.
         rd2_len = np.sum(rd2_overlap)
 
         # Restrict objs to overlap (ovlp) region for calculations.

--- a/refnx/dataset/data1d.py
+++ b/refnx/dataset/data1d.py
@@ -394,7 +394,7 @@ class Data1D:
         
         Returns
         -------
-        Data1D: Concatenation of non-overlap and combined overlap reigons.
+        RDconcat: :class:`refnx.dataset.data1d.Data1D` New dataset with concatenation of non-overlap and combined overlap reigons.
         """
         
         #Check for necessary y_err data:

--- a/refnx/dataset/data1d.py
+++ b/refnx/dataset/data1d.py
@@ -269,14 +269,17 @@ class Data1D:
         Copies the dataset and parameters, including file info.
         Metadata attribute is shallow copied.
         """
-        myData = self.data #tuple
-        copyData = tuple([a.copy() for a in myData]) #copy arrays
-        clone = Data1D(data=copyData)
+        myData = self.data #tuple, returns witih None values.
+        copyData = [] 
+        for a in myData:  # Copy arrays, and exclude None values.
+            if not a is None:
+                copyData.append(a.copy())
+        clone = Data1D(data=tuple(copyData))
         clone.name = self.name
         clone.filename = self.filename
         clone.metadata = self.metadata
         clone.weighted = self.weighted
-        clone._mask = self._mask.copy() if self._mask!=None else None
+        clone._mask = None if self._mask is None else self._mask.copy()
         return clone
 
     def add_data(self, data_tuple, requires_splice=False, trim_trailing=True):
@@ -406,9 +409,9 @@ class Data1D:
         """
         
         #Check for necessary y_err data:
-        if self.y_err == None:
+        if self.y_err is None:
             raise AttributeError("self does not have y_err data.")
-        elif other.y_err == None:
+        elif other.y_err is None:
             raise AttributeError("other does not have y_err data.")
         
         # Create clone objects so data can be sorted without modifying original objects
@@ -443,11 +446,11 @@ class Data1D:
         xovlp = x[overlap_points]
         yovlp = y[overlap_points]
         yerrovlp = yerr[overlap_points]
-        xerrovlp = xerr[overlap_points]
+        xerrovlp = None if xerr is None else xerr[overlap_points]
         bxovlp = bx[rd2_overlap]
         byovlp = by[rd2_overlap]
         byerrovlp = byerr[rd2_overlap]
-        bxerrovlp = bxerr[rd2_overlap]
+        bxerrovlp = None if bxerr is None else bxerr[rd2_overlap]
 
         # If spaced linearly in LogQ, points should overlap.
         # All RD2 should be within the RD1 domain.
@@ -461,7 +464,7 @@ class Data1D:
             x_new = (xdif2 * xovlp[:-1] + xdif1 * xovlp[1:]) / (xdif1 + xdif2)
             y_new = (xdif2 * yovlp[:-1] + xdif1 * yovlp[1:]) / (xdif1 + xdif2)
             # f=ax + by / (a+b), Unc(f) = 1/abs(a+b) * sqrt((a uncx)^2 + (b uncy)^2)
-            xerr_new = np.sqrt(
+            xerr_new = None if xerrovlp is None else np.sqrt(
                 (xdif2 * xerrovlp[:-1])**2 + (xdif1 * xerrovlp[1:])**2) / np.abs(xdif1 + xdif2)
             yerr_new = np.sqrt(
                 (xdif2 * yerrovlp[:-1])**2 + (xdif1 * yerrovlp[1:])**2) / np.abs(xdif1 + xdif2)
@@ -472,7 +475,7 @@ class Data1D:
             wx = (x_new * byerrovlp + bxovlp * yerr_new) / yerr_tot
             wy = (y_new * byerrovlp + byovlp * yerr_new) / yerr_tot
             # f=(a*x + b*y) / (a+b), Unc(f) = 1/abs(a+b) * sqrt((a*uncx)^2 + (b*uncy)^2)
-            wxerr = np.sqrt((xerr_new * byerrovlp)**2 +
+            wxerr = None if (xerr_new is None or bxerr is None) else np.sqrt((xerr_new * byerrovlp)**2 +
                             (bxerrovlp * yerr_new)**2) / yerr_tot
             wyerr = np.sqrt((yerr_new * byerrovlp)**2 +
                             (byerrovlp * yerr_new)**2) / yerr_tot

--- a/refnx/dataset/data1d.py
+++ b/refnx/dataset/data1d.py
@@ -399,6 +399,7 @@ class Data1D:
         
         Notes
         -----
+        self.x is interpolated to match other.x in overlap reigon, before blending.
         Raises `AttributeError` if different data density in overlap reigon.
         Raises `AttributeError` if neither dataset has a y_err attribute.
         Raises `ValueError` if no overlap in x; should use add_data.

--- a/refnx/dataset/data1d.py
+++ b/refnx/dataset/data1d.py
@@ -267,8 +267,16 @@ class Data1D:
     def copy(self):
         """
         Copies the dataset and parameters, including file info.
+        Metadata attribute is shallow copied.
         """
-        clone = Data1D(data=self) #pass Data1D Obj back to constructor to copy.
+        myData = self.data #tuple
+        copyData = tuple([a.copy() for a in myData]) #copy arrays
+        clone = Data1D(data=copyData)
+        clone.name = self.name
+        clone.filename = self.filename
+        clone.metadata = self.metadata
+        clone.weighted = self.weighted
+        clone._mask = self._mask.copy() if self._mask!=None else None
         return clone
 
     def add_data(self, data_tuple, requires_splice=False, trim_trailing=True):

--- a/refnx/dataset/data1d.py
+++ b/refnx/dataset/data1d.py
@@ -72,7 +72,7 @@ class Data1D:
         ):
             self.load(data)
         elif isinstance(data, Data1D):
-            # copy a dataset (but not it's file info)
+            # copy a dataset
             self.name = data.name
             self.filename = data.filename
             self.metadata = data.metadata
@@ -91,10 +91,10 @@ class Data1D:
 
             if len(data) > 3:
                 self._x_err = np.array(data[3], dtype=float)
-
-        self._mask = None
         if mask is not None:
             self._mask = np.broadcast_to(mask, self._y.shape)
+        elif not hasattr(self, "_mask"):
+            self._mask = None #set mask to none if not copied or provided.
 
     def __len__(self):
         """
@@ -263,6 +263,13 @@ class Data1D:
         """
         self._y /= scalefactor
         self._y_err /= scalefactor
+
+    def copy(self):
+        """
+        Copies the dataset and parameters, including file info.
+        """
+        clone = Data1D(data=self) #pass Data1D Obj back to constructor to copy.
+        return clone
 
     def add_data(self, data_tuple, requires_splice=False, trim_trailing=True):
         """

--- a/refnx/dataset/reflectdataset.py
+++ b/refnx/dataset/reflectdataset.py
@@ -84,8 +84,11 @@ class ReflectDataset(Data1D):
         Metadata, sld_profile and datafilenumber attributes are shallow copied.
         """
         myData = self.data  # tuple
-        copyData = tuple([a.copy() for a in myData])
-        clone = ReflectDataset(data=copyData)
+        copyData = []
+        for a in myData:  # Copy arrays, and exclude None values.
+            if not a is None:
+                copyData.append(a.copy())
+        clone = ReflectDataset(data=tuple(copyData))
         clone.name = self.name
         clone.filename = self.filename
         clone.metadata = self.metadata
@@ -201,8 +204,11 @@ class OrsoDataset(Data1D):
         Copies the OrsoDataset base object data. Orso and metadata attributes are shallow copied.
         """
         myData = self.data  # tuple
-        copyData = tuple([a.copy() for a in myData])
-        clone = OrsoDataset(data=copyData)
+        copyData = []
+        for a in myData:  # Copy arrays, and exclude None values.
+            if not a is None:
+                copyData.append(a.copy())
+        clone = OrsoDataset(data=tuple(copyData))
         clone.name = self.name
         clone.filename = self.filename
         clone.metadata = self.metadata

--- a/refnx/dataset/reflectdataset.py
+++ b/refnx/dataset/reflectdataset.py
@@ -78,6 +78,15 @@ class ReflectDataset(Data1D):
         self.datafilenumber = list()
         self.sld_profile = None
 
+    def copy(self):
+        """
+        Copies the ReflectDataset object.
+        """
+        clone = super().copy()
+        clone.datafilenumber = self.datafilenumber
+        clone.sld_profile = self.sld_profile
+        return clone
+
     def __repr__(self):
         msk = self._mask
         if np.all(self._mask):
@@ -178,6 +187,15 @@ class OrsoDataset(Data1D):
         super().__init__(data=data, **kwds)
         self.orso = None
 
+
+    def copy(self):
+        """
+        Copies the OrsoDataset object.
+        """
+        clone = super().copy()
+        clone.orso = self.orso
+        return clone
+        
     def load(self, f):
         """
         Parameters

--- a/refnx/dataset/reflectdataset.py
+++ b/refnx/dataset/reflectdataset.py
@@ -80,9 +80,17 @@ class ReflectDataset(Data1D):
 
     def copy(self):
         """
-        Copies the ReflectDataset object.
+        Copies the ReflectDataset object. 
+        Metadata, sld_profile and datafilenumber attributes are shallow copied.
         """
-        clone = super().copy()
+        myData = self.data  # tuple
+        copyData = tuple([a.copy() for a in myData])
+        clone = ReflectDataset(data=copyData)
+        clone.name = self.name
+        clone.filename = self.filename
+        clone.metadata = self.metadata
+        clone.weighted = self.weighted
+        clone._mask = self._mask.copy() if self._mask != None else None
         clone.datafilenumber = self.datafilenumber
         clone.sld_profile = self.sld_profile
         return clone
@@ -190,9 +198,16 @@ class OrsoDataset(Data1D):
 
     def copy(self):
         """
-        Copies the OrsoDataset object.
+        Copies the OrsoDataset base object data. Orso and metadata attributes are shallow copied.
         """
-        clone = super().copy()
+        myData = self.data  # tuple
+        copyData = tuple([a.copy() for a in myData])
+        clone = OrsoDataset(data=copyData)
+        clone.name = self.name
+        clone.filename = self.filename
+        clone.metadata = self.metadata
+        clone.weighted = self.weighted
+        clone._mask = self._mask.copy() if self._mask != None else None
         clone.orso = self.orso
         return clone
         


### PR DESCRIPTION
Added a new function to blend data, which statistically combines overlapping data using y-err weighting. This is unique functionality and different to the truncate options of add_data, allowing seamless combination of datasets where y-err is optimized.

Also added copy functions to data1D & parent classes. Copy method is used to isolate raw data arrays. Metadata, Orso, sld_profile and datafilenumber are shallow copied.

Lastly, ensured that the initializer doesn't always set `self._mask` to `None`, especially if copying a dataset (passed through the constructor).