### PR TITLE
MAINT: write_offspec in 4 column ascii

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -551,3 +551,5 @@ in 0.1.13.
   WindowsPath and vice versa.
 - modified `util.general.neutron_transmission` to be able to select which cross
   sections are used for transmission calculation.
+- We revised the ReflectReduce.write_offspecular to output an ascii file with 
+  four columns, qz,qx,m_ref, m_ref_err.

--- a/refnx/reduce/reduce.py
+++ b/refnx/reduce/reduce.py
@@ -450,8 +450,8 @@ class ReflectReduce:
         scanpoint : int
         """
         offspec_map = np.c_[
-            self.qz[scanpoint].ravel(),
-            self.qx[scanpoint].ravel(),
+            self.m_qz[scanpoint].ravel(),
+            self.m_qx[scanpoint].ravel(),
             self.m_ref[scanpoint].ravel(),
             self.m_ref_err[scanpoint].ravel(),
         ]

--- a/refnx/reduce/reduce.py
+++ b/refnx/reduce/reduce.py
@@ -438,28 +438,24 @@ class ReflectReduce:
         self.y_err /= scale
 
     def write_offspecular(self, f, scanpoint=0):
-        d = dict()
-        d["time"] = strftime("%a, %d %b %Y %H:%M:%S +0000", gmtime())
-        d["_rnumber"] = self.reflected_beam.datafile_number
-        d["_numpointsz"] = np.size(self.m_ref, 1)
-        d["_numpointsy"] = np.size(self.m_ref, 2)
+        """
+        Writes reduced offspecular data to a file
 
-        s = string.Template(_template_ref_xml)
-
-        # filename = 'off_PLP{:07d}_{:d}.xml'.format(self._rnumber, index)
-        d["_r"] = repr(self.m_ref[scanpoint].tolist()).strip(",[]")
-        d["_qz"] = repr(self.m_qz[scanpoint].tolist()).strip(",[]")
-        d["_dr"] = repr(self.m_ref_err[scanpoint].tolist()).strip(",[]")
-        d["_qx"] = repr(self.m_qx[scanpoint].tolist()).strip(",[]")
-
-        thefile = s.safe_substitute(d)
-
-        with possibly_open_file(f, "wb") as g:
-            if "b" in g.mode:
-                thefile = thefile.encode("utf-8")
-
-            g.write(thefile)
-            g.truncate()
+        Parameters
+        ----------
+        f : {str, filehandle}
+            Uses np.savetxt to save data. If the filename ends in .gz, the file is
+            automatically saved in compressed gzip format. loadtxt understands
+            gzipped files transparently.
+        scanpoint : int
+        """
+        offspec_map = np.c_[
+            self.qz[scanpoint].ravel(),
+            self.qx[scanpoint].ravel(),
+            self.m_ref[scanpoint].ravel(),
+            self.m_ref_err[scanpoint].ravel(),
+        ]
+        np.savetxt(f, offspec_map, header="qz qx m_ref m_ref_err")
 
     def _create_metadata_header(self):
         header = []

--- a/refnx/reduce/test/test_reduce.py
+++ b/refnx/reduce/test/test_reduce.py
@@ -102,7 +102,7 @@ class TestPlatypusReduce:
             ReflectDataset("./PLP0000708_0.dat")
 
             # try writing offspecular data
-            a.write_offspecular("offspec.xml", 0)
+            a.write_offspecular("offspec.dat.gz", 0)
 
     def test_detailed_kernel(self):
         with warnings.catch_warnings():


### PR DESCRIPTION
We revised the `ReflectReduce.write_offspecular`  to output an ascii file with four columns, qz,qx,m_ref, m_ref_err.