### PR TITLE
BUG: Fix plot os label

### DIFF
--- a/refnx/reduce/platypusnexus.py
+++ b/refnx/reduce/platypusnexus.py
@@ -3550,8 +3550,8 @@ def _plot_offspec(
     ax.set_xlim(Qx_interval)
     ax.set_ylim(Qz_interval)
     ax.locator_params(axis="x", nbins=3)
-    ax.set_ylabel(r"$Q_z (\\AA^{-1})$")
-    ax.set_xlabel(r"$Q_x (\\AA^{-1})$")
+    ax.set_ylabel(r"$Q_z (\AA^{-1})$")
+    ax.set_xlabel(r"$Q_x (\AA^{-1})$")
     cb = fig.colorbar(contour)
     cb.ax.set_ylabel("Intensity")
 


### PR DESCRIPTION
Minor error when plotting caused by escape character "\\" in the ax.set_ylabel(r"$Q_z (\\AA^{-1})$"), in Jupyter notebook. 

Jupyter NB returned was " ParseException: Expected end of text, found '$'  (at char 0), (line:1, col:1)"

Remedied by replacing "\\" with "\"