### PR TITLE
[BUG] Force event-mode logs to be read as LE int32

### DIFF
--- a/src/_cevent.pyx
+++ b/src/_cevent.pyx
@@ -49,7 +49,7 @@ def event_header(buffer):
     depending on whether the event file is packed or unpacked. This can be
     determined by checking `base.pack_format`, 0 == PACKED, 1 == UNPACKED.
     """
-    header_arr = np.frombuffer(buffer[:128], dtype='int32')
+    header_arr = np.frombuffer(buffer[:128], dtype='<i4')
 
     base = EventFileHeader_Base(magic_number=header_arr[0],
                                 format_number=header_arr[1],


### PR DESCRIPTION
Fix event data processing on big-endian architechtures: The event-mode files in the data bundle for the tests are always little-endian as they are generated on the insturment machines. Opening the files needs to be specific about the byte-order and not open with an implicitly native byte-order as np.frombuffer normally does.

Test failure observed on the Debian s390x CI workers. 
https://ci.debian.net/packages/r/refnx/testing/s390x/
```
reduce/test/test_platypusnexus.py::TestPlatypusNexus::test_event FAILED  [ 45%]
reduce/test/test_platypusnexus.py::TestPlatypusNexus::test_event_folder FAILED [ 45%]
reduce/test/test_platypusnexus.py::TestPlatypusNexus::test_reduction_runs FAILED [ 46%]
reduce/test/test_reduce.py::TestPlatypusReduce::test_event_reduction FAILED [ 55%]

 E   AssertionError
 src/_cevent.pyx:60: AssertionError
```
https://wiki.debian.org/ArchitectureSpecificsMemo