### PR TITLE
TST: relax rtol on kernel comparison

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -633,3 +633,4 @@ in 0.1.13.
 
 0.1.52
 ------
+- relax reflection kernel accuracy for i386. Necessary for Debian build.

--- a/refnx/reflect/test/test_reflect.py
+++ b/refnx/reflect/test/test_reflect.py
@@ -182,13 +182,14 @@ class TestReflect:
         kf = kn(q, sld2, sld2)
         kb = kn(q, sld1, sld2)
         reflectance = (kf - kb) / (kf + kb)
-        reflectivity = reflectance * np.conj(reflectance)
+        reflectivity = np.real(reflectance * np.conj(reflectance))
 
         # now from refnx code
         struct = SLD(sld2)(0, 0) | SLD(sld1)(0, 0)
         slabs = struct.slabs()[..., :4]
         with use_reflect_backend(backend) as kernel:
-            assert_allclose(kernel(q, slabs), reflectivity, rtol=1e-14)
+            # adjusted rtol to allow leeway for 32 bit FPU
+            assert_allclose(kernel(q, slabs), reflectivity, rtol=1e-9)
 
     @pytest.mark.filterwarnings("ignore:Using the SLOW")
     def test_scale_bkg_kernel(self):


### PR DESCRIPTION
@llimeht this might work? The maximum rtol difference that I could see in the Debian build log was 2.01e-12. I've relaxed it to  1e-9, which should be more than enough.

I also noticed that there were a lot of warnings building the documentation. A good place to help out would be to investigate whether it's Debian emitting those warnings, or if refnx can improve it's doc building at all. TBH restructured text gives me nightmares. I wish I could do everything in markdown. I think sphinx can do that, but it'd be a bother to transfer to MD.