### PR TITLE
feat: Added kwargs passthough to emcee.EnsembleSampler.sample() method

### DIFF
--- a/refnx/analysis/curvefitter.py
+++ b/refnx/analysis/curvefitter.py
@@ -563,7 +563,7 @@ class CurveFitter:
         callback=None,
         verbose=True,
         pool=-1,
-        sampler_kws=None,
+        **sampler_kws,
     ):
         """
         Performs sampling from the objective.
@@ -680,7 +680,7 @@ class CurveFitter:
 
         # Passthough sampler_kws to the sampler.sample method outside of the
         # parallelisation context.
-        sampler_kws = sampler_kws or {}
+        sampler_kws = {} if sampler_kws is None else sampler_kws
         sampler_args = getargspec(self.sampler.sample).args
 
         # update sampler_kws with the sampler_args from instantiated Fitter.


### PR DESCRIPTION
# Added kwargs passthough to `emcee.EnsembleSampler.sample()` method

Updated how the kwargs for `EnsembleSampler.smaple()` are generated, exposing them to the `CurveFitter.sample()` method call. Moved the generation of sampling kwargs out of the thread pool context manager, leaving behind the pool dependent arguments. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

Doc-strings where updated to reflect the new `sampler_kws` parameter. 

# Testing
This successfully allows for toggling both the `skip_initial_state_check` and `store` parameters.

**Test Configuration**:
* Firmware version: ubuntu-latest
* Hardware: x86-64
* Toolchain: Python 3.12 & uv

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

