### PR TITLE
CI: scope GITHUB_TOKEN permissions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   build_wheels:
     runs-on: ${{ matrix.os }}
@@ -158,6 +161,8 @@ jobs:
   release-github:
     runs-on: ubuntu-latest
     needs: [ pypi-publish ]
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Add explicit workflow-level `permissions: contents: read` to release.yml (matching pythonpackage.yml), and grant `contents: write` only on the release-github job, which is the sole job that needs it to publish a GitHub release.